### PR TITLE
Publish Docker Image on Commit

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -2,6 +2,8 @@ name: Create and publish a Docker image
 
 on:
   push:
+    tags:
+    - '**'
     branches:
     - '**'
 


### PR DESCRIPTION
WIP: Working on publishing a Docker image to GitHub packages registry each time there is a new commit to the main branch