### PR TITLE
Make Cosigner RPC Server Timeout Value Configurable

### DIFF
--- a/cmd/horcrux/cmd/config.go
+++ b/cmd/horcrux/cmd/config.go
@@ -126,7 +126,7 @@ func initCmd() *cobra.Command {
 	cmd.Flags().StringP("peers", "p", "", "cosigner peer addresses in format tcp://{addr}:{port}|{share-id} (i.e. \"tcp://node-1:2222|2,tcp://node-2:2222|3\")")
 	cmd.Flags().IntP("threshold", "t", 0, "indicate number of signatures required for threshold signature")
 	cmd.Flags().StringP("listen", "l", "tcp://0.0.0.0:2222", "listen address of the signer")
-	cmd.Flags().Int("timeout", 1000, "configure cosigner rpc server timeout value, "+
+	cmd.Flags().Int("timeout", 1500, "configure cosigner rpc server timeout value, "+
 		"units are in milliseconds e.g. 1000 = 1 second ")
 	return cmd
 }
@@ -161,9 +161,9 @@ func validateCosignerConfig(cfg *Config) error {
 	if cfg.CosignerConfig.Threshold < 2 {
 		return fmt.Errorf("threshold must be 2 or greater")
 	}
-	if cfg.CosignerConfig.Timeout < 1 || cfg.CosignerConfig.Timeout > 1500 {
-		return fmt.Errorf("(%d) is an invalid timeout value. "+
-			"cosigner RPC server timeout must be greater than 0ms and less than 1500ms", cfg.CosignerConfig.Timeout)
+	if cfg.CosignerConfig.Timeout < 1 {
+		return fmt.Errorf("(%d) is an invalid timeout value. cosigner RPC server timeout must be greater than 0ms ",
+			cfg.CosignerConfig.Timeout)
 	}
 	if _, err := url.Parse(cfg.CosignerConfig.P2PListen); err != nil {
 		return fmt.Errorf("failed to parse p2p listen address")

--- a/cmd/horcrux/cmd/config.go
+++ b/cmd/horcrux/cmd/config.go
@@ -8,6 +8,7 @@ import (
 	"path"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
@@ -67,7 +68,7 @@ func initCmd() *cobra.Command {
 				threshold, _ := cmd.Flags().GetInt("threshold")
 				peers, err := peersFromFlag(p)
 				listen, _ := cmd.Flags().GetString("listen")
-				timeout, _ := cmd.Flags().GetInt("timeout")
+				timeout, _ := cmd.Flags().GetString("timeout")
 
 				if err != nil {
 					return err
@@ -123,11 +124,12 @@ func initCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolP("cosigner", "c", false, "set to initialize a cosigner node, requires --peers and --threshold")
-	cmd.Flags().StringP("peers", "p", "", "cosigner peer addresses in format tcp://{addr}:{port}|{share-id} (i.e. \"tcp://node-1:2222|2,tcp://node-2:2222|3\")")
+	cmd.Flags().StringP("peers", "p", "", "cosigner peer addresses in format tcp://{addr}:{port}|{share-id} \n"+
+		"(i.e. \"tcp://node-1:2222|2,tcp://node-2:2222|3\")")
 	cmd.Flags().IntP("threshold", "t", 0, "indicate number of signatures required for threshold signature")
 	cmd.Flags().StringP("listen", "l", "tcp://0.0.0.0:2222", "listen address of the signer")
-	cmd.Flags().Int("timeout", 1500, "configure cosigner rpc server timeout value, "+
-		"units are in milliseconds e.g. 1000 = 1 second ")
+	cmd.Flags().String("timeout", "1500ms", "configure cosigner rpc server timeout value, \n"+
+		"accepts valid duration strings for Go's time.ParseDuration() e.g. 1s, 1000ms, 1.5m")
 	return cmd
 }
 
@@ -158,12 +160,10 @@ func validateCosignerConfig(cfg *Config) error {
 	if len(cfg.CosignerConfig.Peers)+1 < cfg.CosignerConfig.Threshold {
 		return fmt.Errorf("number of peers + 1 (%d) must be greater than threshold (%d)", len(cfg.CosignerConfig.Peers)+1, cfg.CosignerConfig.Threshold)
 	}
-	if cfg.CosignerConfig.Threshold < 2 {
-		return fmt.Errorf("threshold must be 2 or greater")
-	}
-	if cfg.CosignerConfig.Timeout < 1 {
-		return fmt.Errorf("(%d) is an invalid timeout value. cosigner RPC server timeout must be greater than 0ms ",
-			cfg.CosignerConfig.Timeout)
+
+	_, err := time.ParseDuration(cfg.CosignerConfig.Timeout)
+	if err != nil {
+		return fmt.Errorf("%s is not a valid duration string for --timeout ", cfg.CosignerConfig.Timeout)
 	}
 	if _, err := url.Parse(cfg.CosignerConfig.P2PListen); err != nil {
 		return fmt.Errorf("failed to parse p2p listen address")
@@ -203,7 +203,7 @@ type CosignerConfig struct {
 	Threshold int            `json:"threshold"   yaml:"threshold"`
 	P2PListen string         `json:"p2p-listen"  yaml:"p2p-listen"`
 	Peers     []CosignerPeer `json:"peers"       yaml:"peers"`
-	Timeout   int            `json:"rpc-timeout" yaml:"rpc-timeout"`
+	Timeout   string         `json:"rpc-timeout" yaml:"rpc-timeout"`
 }
 
 func (c *Config) CosignerPeers() (out []signer.CosignerConfig) {

--- a/cmd/horcrux/cmd/cosigner.go
+++ b/cmd/horcrux/cmd/cosigner.go
@@ -163,11 +163,7 @@ func StartCosignerCmd() *cobra.Command {
 					Peers:     cosigners,
 				})
 
-				duration := fmt.Sprintf("%d%s", config.CosignerConfig.Timeout, "ms")
-				timeout, err := time.ParseDuration(duration)
-				if err != nil {
-					return fmt.Errorf("%s is not a valid duration string for --timeout ", timeout)
-				}
+				timeout, _ := time.ParseDuration(config.CosignerConfig.Timeout)
 				rpcServerConfig := signer.CosignerRpcServerConfig{
 					Logger:        logger,
 					ListenAddress: cfg.ListenAddress,

--- a/signer/cosigner_rpc_server.go
+++ b/signer/cosigner_rpc_server.go
@@ -42,6 +42,7 @@ type CosignerRpcServerConfig struct {
 	ListenAddress string
 	Cosigner      Cosigner
 	Peers         []RemoteCosigner
+	Timeout       time.Duration
 }
 
 // CosignerRpcServer responds to rpc sign requests using a cosigner instance
@@ -53,6 +54,7 @@ type CosignerRpcServer struct {
 	listener      net.Listener
 	cosigner      Cosigner
 	peers         []RemoteCosigner
+	timeout       time.Duration
 }
 
 // NewCosignerRpcServer instantiates a local cosigner with the specified key and sign state
@@ -62,6 +64,7 @@ func NewCosignerRpcServer(config *CosignerRpcServerConfig) *CosignerRpcServer {
 		listenAddress: config.ListenAddress,
 		peers:         config.Peers,
 		logger:        config.Logger,
+		timeout:       config.Timeout,
 	}
 
 	cosignerRpcServer.BaseService = *service.NewBaseService(config.Logger, "CosignerRpcServer", cosignerRpcServer)
@@ -124,7 +127,7 @@ func (rpcServer *CosignerRpcServer) rpcSignRequest(ctx *rpc_types.Context, req R
 
 			// RPC requests are blocking
 			// to prevent it from hanging our process indefinitely, we use a timeout context and a goroutine
-			partReqCtx, partReqCtxCancel := context.WithTimeout(context.Background(), time.Second)
+			partReqCtx, partReqCtxCancel := context.WithTimeout(context.Background(), rpcServer.timeout)
 
 			go func() {
 				partRequest := CosignerGetEphemeralSecretPartRequest{


### PR DESCRIPTION
The proposed changes would make the Cosigner RPC server have a configurable timeout value (as requested in #25 ) that can be set with `horcrux cosigner start --timeout str`  and when no flag is provided the default value is set to 1 second.

The accepted values for `--timeout str` are those that are accepted by Go's `time.ParseDuration()` function

From [https://pkg.go.dev/time#Duration](url)
```
ParseDuration parses a duration string. A duration string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
```

Edit: Added this to `cmd/config` instead. The flag will now instead take in an int representing the timeout value in milliseconds with a default value of 1500ms