### PR TITLE
Refactor Cosigner/Signer Start

### DIFF
--- a/cmd/horcrux/cmd/cosigner.go
+++ b/cmd/horcrux/cmd/cosigner.go
@@ -25,7 +25,7 @@ func init() {
 
 var cosignerCmd = &cobra.Command{
 	Use:   "cosigner",
-	Short: "A brief description of your command",
+	Short: "Threshold mpc signer for TM based nodes",
 }
 
 func StartCosignerCmd() *cobra.Command {
@@ -214,6 +214,5 @@ func StartCosignerCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolP("single", "s", false, "set to start horcrux as a single signer")
 	return cmd
 }

--- a/cmd/horcrux/cmd/cosigner.go
+++ b/cmd/horcrux/cmd/cosigner.go
@@ -14,7 +14,6 @@ import (
 	tmlog "github.com/tendermint/tendermint/libs/log"
 	tmOS "github.com/tendermint/tendermint/libs/os"
 	tmService "github.com/tendermint/tendermint/libs/service"
-	"github.com/tendermint/tendermint/privval"
 	"github.com/tendermint/tendermint/types"
 )
 
@@ -34,14 +33,8 @@ func StartCosignerCmd() *cobra.Command {
 		Short: "start cosigner process",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			single, _ := cmd.Flags().GetBool("single")
 
-			if single {
-				err = validateSingleSignerConfig(config)
-			} else {
-				err = validateCosignerConfig(config)
-			}
-
+			err = validateCosignerConfig(config)
 			if err != nil {
 				return
 			}
@@ -55,25 +48,15 @@ func StartCosignerCmd() *cobra.Command {
 				cfg      signer.Config
 			)
 
-			if single {
-				cfg = signer.Config{
-					Mode:            "single",
-					PrivValKeyFile:  path.Join(config.HomeDir, "priv_validator_key.json"),
-					PrivValStateDir: path.Join(config.HomeDir, "state"),
-					ChainID:         config.ChainID,
-					Nodes:           config.Nodes(),
-				}
-			} else {
-				cfg = signer.Config{
-					Mode:              "mpc",
-					PrivValKeyFile:    path.Join(config.HomeDir, "share.json"),
-					PrivValStateDir:   path.Join(config.HomeDir, "state"),
-					ChainID:           config.ChainID,
-					CosignerThreshold: config.CosignerConfig.Threshold,
-					ListenAddress:     config.CosignerConfig.P2PListen,
-					Nodes:             config.Nodes(),
-					Cosigners:         config.CosignerPeers(),
-				}
+			cfg = signer.Config{
+				Mode:              "mpc",
+				PrivValKeyFile:    path.Join(config.HomeDir, "share.json"),
+				PrivValStateDir:   path.Join(config.HomeDir, "state"),
+				ChainID:           config.ChainID,
+				CosignerThreshold: config.CosignerConfig.Threshold,
+				ListenAddress:     config.CosignerConfig.P2PListen,
+				Nodes:             config.Nodes(),
+				Cosigners:         config.CosignerPeers(),
 			}
 
 			if _, err = os.Stat(cfg.PrivValKeyFile); os.IsNotExist(err) {
@@ -83,101 +66,87 @@ func StartCosignerCmd() *cobra.Command {
 			logger.Info("Tendermint Validator", "mode", cfg.Mode, "priv-key", cfg.PrivValKeyFile, "priv-state-dir", cfg.PrivValStateDir)
 
 			var val types.PrivValidator
-			if single {
-				stateFile := path.Join(cfg.PrivValStateDir, fmt.Sprintf("%s_priv_validator_state.json", chainID))
 
-				// TODO either stop creating state file at config init
-				// Triple check that this is how we will handle state file and that this behaves as intended
-				// if f, err := os.Stat(stateFile); os.IsNotExist(err) || f.Size() == 0 {
-				//  	val = privval.LoadFilePVEmptyState(cfg.PrivValKeyFile, stateFile)
-				// 	} else {
-				//  	val = privval.LoadFilePV(cfg.PrivValKeyFile, stateFile)
-				//  }
-				val = privval.LoadFilePVEmptyState(cfg.PrivValKeyFile, stateFile)
-
-				pv = &signer.PvGuard{PrivValidator: val}
-			} else {
-				key, err := signer.LoadCosignerKey(cfg.PrivValKeyFile)
-				if err != nil {
-					return fmt.Errorf("error reading cosigner key: %s", err)
-				}
-
-				// ok to auto initialize on disk since the cosigner share is the one that actually
-				// protects against double sign - this exists as a cache for the final signature
-				stateFile := path.Join(cfg.PrivValStateDir, fmt.Sprintf("%s_priv_validator_state.json", chainID))
-				signState, err := signer.LoadOrCreateSignState(stateFile)
-				if err != nil {
-					panic(err)
-				}
-
-				// state for our cosigner share
-				// Not automatically initialized on disk to avoid double sign risk
-				shareStateFile := path.Join(cfg.PrivValStateDir, fmt.Sprintf("%s_share_sign_state.json", chainID))
-				shareSignState, err := signer.LoadSignState(shareStateFile)
-				if err != nil {
-					panic(err)
-				}
-
-				cosigners := []signer.Cosigner{}
-				remoteCosigners := []signer.RemoteCosigner{}
-
-				// add ourselves as a peer so localcosigner can handle GetEphSecPart requests
-				peers := []signer.CosignerPeer{{
-					ID:        key.ID,
-					PublicKey: key.RSAKey.PublicKey,
-				}}
-
-				for _, cosignerConfig := range cfg.Cosigners {
-					cosigner := signer.NewRemoteCosigner(cosignerConfig.ID, cosignerConfig.Address)
-					cosigners = append(cosigners, cosigner)
-					remoteCosigners = append(remoteCosigners, *cosigner)
-
-					if cosignerConfig.ID < 1 || cosignerConfig.ID > len(key.CosignerKeys) {
-						log.Fatalf("Unexpected cosigner ID %d", cosignerConfig.ID)
-					}
-
-					pubKey := key.CosignerKeys[cosignerConfig.ID-1]
-					peers = append(peers, signer.CosignerPeer{
-						ID:        cosigner.GetID(),
-						PublicKey: *pubKey,
-					})
-				}
-
-				total := len(cfg.Cosigners) + 1
-				localCosignerConfig := signer.LocalCosignerConfig{
-					CosignerKey: key,
-					SignState:   &shareSignState,
-					RsaKey:      key.RSAKey,
-					Peers:       peers,
-					Total:       uint8(total),
-					Threshold:   uint8(cfg.CosignerThreshold),
-				}
-
-				localCosigner := signer.NewLocalCosigner(localCosignerConfig)
-
-				val := signer.NewThresholdValidator(&signer.ThresholdValidatorOpt{
-					Pubkey:    key.PubKey,
-					Threshold: cfg.CosignerThreshold,
-					SignState: signState,
-					Cosigner:  localCosigner,
-					Peers:     cosigners,
-				})
-
-				timeout, _ := time.ParseDuration(config.CosignerConfig.Timeout)
-				rpcServerConfig := signer.CosignerRpcServerConfig{
-					Logger:        logger,
-					ListenAddress: cfg.ListenAddress,
-					Cosigner:      localCosigner,
-					Peers:         remoteCosigners,
-					Timeout:       timeout,
-				}
-
-				rpcServer := signer.NewCosignerRpcServer(&rpcServerConfig)
-				rpcServer.Start()
-				services = append(services, rpcServer)
-
-				pv = &signer.PvGuard{PrivValidator: val}
+			key, err := signer.LoadCosignerKey(cfg.PrivValKeyFile)
+			if err != nil {
+				return fmt.Errorf("error reading cosigner key: %s", err)
 			}
+
+			// ok to auto initialize on disk since the cosigner share is the one that actually
+			// protects against double sign - this exists as a cache for the final signature
+			stateFile := path.Join(cfg.PrivValStateDir, fmt.Sprintf("%s_priv_validator_state.json", chainID))
+			signState, err := signer.LoadOrCreateSignState(stateFile)
+			if err != nil {
+				panic(err)
+			}
+
+			// state for our cosigner share
+			// Not automatically initialized on disk to avoid double sign risk
+			shareStateFile := path.Join(cfg.PrivValStateDir, fmt.Sprintf("%s_share_sign_state.json", chainID))
+			shareSignState, err := signer.LoadSignState(shareStateFile)
+			if err != nil {
+				panic(err)
+			}
+
+			cosigners := []signer.Cosigner{}
+			remoteCosigners := []signer.RemoteCosigner{}
+
+			// add ourselves as a peer so localcosigner can handle GetEphSecPart requests
+			peers := []signer.CosignerPeer{{
+				ID:        key.ID,
+				PublicKey: key.RSAKey.PublicKey,
+			}}
+
+			for _, cosignerConfig := range cfg.Cosigners {
+				cosigner := signer.NewRemoteCosigner(cosignerConfig.ID, cosignerConfig.Address)
+				cosigners = append(cosigners, cosigner)
+				remoteCosigners = append(remoteCosigners, *cosigner)
+
+				if cosignerConfig.ID < 1 || cosignerConfig.ID > len(key.CosignerKeys) {
+					log.Fatalf("Unexpected cosigner ID %d", cosignerConfig.ID)
+				}
+
+				pubKey := key.CosignerKeys[cosignerConfig.ID-1]
+				peers = append(peers, signer.CosignerPeer{
+					ID:        cosigner.GetID(),
+					PublicKey: *pubKey,
+				})
+			}
+
+			total := len(cfg.Cosigners) + 1
+			localCosignerConfig := signer.LocalCosignerConfig{
+				CosignerKey: key,
+				SignState:   &shareSignState,
+				RsaKey:      key.RSAKey,
+				Peers:       peers,
+				Total:       uint8(total),
+				Threshold:   uint8(cfg.CosignerThreshold),
+			}
+
+			localCosigner := signer.NewLocalCosigner(localCosignerConfig)
+
+			val = signer.NewThresholdValidator(&signer.ThresholdValidatorOpt{
+				Pubkey:    key.PubKey,
+				Threshold: cfg.CosignerThreshold,
+				SignState: signState,
+				Cosigner:  localCosigner,
+				Peers:     cosigners,
+			})
+
+			timeout, _ := time.ParseDuration(config.CosignerConfig.Timeout)
+			rpcServerConfig := signer.CosignerRpcServerConfig{
+				Logger:        logger,
+				ListenAddress: cfg.ListenAddress,
+				Cosigner:      localCosigner,
+				Peers:         remoteCosigners,
+				Timeout:       timeout,
+			}
+
+			rpcServer := signer.NewCosignerRpcServer(&rpcServerConfig)
+			rpcServer.Start()
+			services = append(services, rpcServer)
+
+			pv = &signer.PvGuard{PrivValidator: val}
 
 			pubkey, err := pv.GetPubKey()
 			if err != nil {

--- a/cmd/horcrux/cmd/signer.go
+++ b/cmd/horcrux/cmd/signer.go
@@ -1,0 +1,117 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"path"
+	"sync"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/strangelove-ventures/horcrux/signer"
+	tmlog "github.com/tendermint/tendermint/libs/log"
+	tmOS "github.com/tendermint/tendermint/libs/os"
+	tmService "github.com/tendermint/tendermint/libs/service"
+	"github.com/tendermint/tendermint/privval"
+	"github.com/tendermint/tendermint/types"
+)
+
+func init() {
+	signerCmd.AddCommand(StartSignerCmd())
+	rootCmd.AddCommand(signerCmd)
+}
+
+var signerCmd = &cobra.Command{
+	Use:   "signer",
+	Short: "Single signer mode for TM remote tx signer.",
+}
+
+func StartSignerCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "start",
+		Short: "start single signer process",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+
+			err = validateSingleSignerConfig(config)
+
+			if err != nil {
+				return
+			}
+
+			var (
+				// services to stop on shutdown
+				services []tmService.Service
+				pv       types.PrivValidator
+				chainID  = config.ChainID
+				logger   = tmlog.NewTMLogger(tmlog.NewSyncWriter(os.Stdout)).With("module", "validator")
+				cfg      signer.Config
+			)
+
+			cfg = signer.Config{
+				Mode:            "single",
+				PrivValKeyFile:  path.Join(config.HomeDir, "priv_validator_key.json"),
+				PrivValStateDir: path.Join(config.HomeDir, "state"),
+				ChainID:         config.ChainID,
+				Nodes:           config.Nodes(),
+			}
+
+			if _, err = os.Stat(cfg.PrivValKeyFile); os.IsNotExist(err) {
+				return fmt.Errorf("private key share doesn't exist at path(%s)", cfg.PrivValKeyFile)
+			}
+
+			logger.Info("Tendermint Validator", "mode", cfg.Mode, "priv-key", cfg.PrivValKeyFile, "priv-state-dir", cfg.PrivValStateDir)
+
+			var val types.PrivValidator
+			stateFile := path.Join(cfg.PrivValStateDir, fmt.Sprintf("%s_priv_validator_state.json", chainID))
+
+			// TODO either stop creating state file at config init
+			// Triple check that this is how we will handle state file and that this behaves as intended
+			// if f, err := os.Stat(stateFile); os.IsNotExist(err) || f.Size() == 0 {
+			//  	val = privval.LoadFilePVEmptyState(cfg.PrivValKeyFile, stateFile)
+			// 	} else {
+			//  	val = privval.LoadFilePV(cfg.PrivValKeyFile, stateFile)
+			//  }
+			val = privval.LoadFilePVEmptyState(cfg.PrivValKeyFile, stateFile)
+
+			pv = &signer.PvGuard{PrivValidator: val}
+
+			pubkey, err := pv.GetPubKey()
+			if err != nil {
+				log.Fatal(err)
+			}
+			logger.Info("Signer", "pubkey", pubkey)
+
+			for _, node := range cfg.Nodes {
+				dialer := net.Dialer{Timeout: 30 * time.Second}
+				s := signer.NewReconnRemoteSigner(node.Address, logger, cfg.ChainID, pv, dialer)
+
+				err := s.Start()
+				if err != nil {
+					panic(err)
+				}
+
+				services = append(services, s)
+			}
+
+			wg := sync.WaitGroup{}
+			wg.Add(1)
+			tmOS.TrapSignal(logger, func() {
+				for _, service := range services {
+					err := service.Stop()
+					if err != nil {
+						panic(err)
+					}
+				}
+				wg.Done()
+			})
+			wg.Wait()
+
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/signer/Config.go
+++ b/signer/Config.go
@@ -1,6 +1,7 @@
 package signer
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/BurntSushi/toml"
@@ -38,4 +39,11 @@ func LoadConfigFromFile(file string) (Config, error) {
 	}
 	_, err = toml.DecodeReader(reader, &config)
 	return config, err
+}
+
+func (cfg *Config) KeyFileExists() error {
+	if _, err := os.Stat(cfg.PrivValKeyFile); os.IsNotExist(err) {
+		return fmt.Errorf("private key share doesn't exist at path(%s)", cfg.PrivValKeyFile)
+	}
+	return nil
 }

--- a/signer/remote_signer.go
+++ b/signer/remote_signer.go
@@ -199,3 +199,19 @@ func (rs *ReconnRemoteSigner) handleRequest(req tmProtoPrivval.Message) (tmProto
 
 	return msg, err
 }
+
+func StartRemoteSigners(services []tmService.Service, logger tmLog.Logger, chainID string, privVal tm.PrivValidator, nodes []NodeConfig) ([]tmService.Service, error) {
+	var err error
+	for _, node := range nodes {
+		dialer := net.Dialer{Timeout: 30 * time.Second}
+		s := NewReconnRemoteSigner(node.Address, logger, chainID, privVal, dialer)
+
+		err = s.Start()
+		if err != nil {
+			return nil, err
+		}
+
+		services = append(services, s)
+	}
+	return services, err
+}

--- a/signer/services.go
+++ b/signer/services.go
@@ -1,0 +1,24 @@
+package signer
+
+import (
+	"sync"
+
+	tmLog "github.com/tendermint/tendermint/libs/log"
+	tmOS "github.com/tendermint/tendermint/libs/os"
+	tmService "github.com/tendermint/tendermint/libs/service"
+)
+
+func WaitAndTerminate(logger tmLog.Logger, services []tmService.Service) {
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	tmOS.TrapSignal(logger, func() {
+		for _, service := range services {
+			err := service.Stop()
+			if err != nil {
+				panic(err)
+			}
+		}
+		wg.Done()
+	})
+	wg.Wait()
+}

--- a/test/signer_test.go
+++ b/test/signer_test.go
@@ -367,7 +367,7 @@ func (ts *TestSigner) CreateSingleSignerContainer(networkID string) error {
 		Name: ts.Name(),
 		Config: &docker.Config{
 			User:     getDockerUserString(),
-			Cmd:      []string{"horcrux", "cosigner", "start", "--single", fmt.Sprintf("--home=%s", ts.Dir())},
+			Cmd:      []string{"horcrux", "signer", "start", fmt.Sprintf("--home=%s", ts.Dir())},
 			Hostname: ts.Name(),
 			ExposedPorts: map[docker.Port]struct{}{
 				docker.Port(fmt.Sprintf("%s/tcp", signerPort)): {},


### PR DESCRIPTION
This refactor seeks to close out issue #12 

`cmd/cosigner.go` will have the single signer functionality removed and stuck in its own cmd, `cmd/signer.go`
