### PR TITLE
Add commands to read and modify config and state files

### DIFF
--- a/cmd/horcrux/cmd/config.go
+++ b/cmd/horcrux/cmd/config.go
@@ -19,8 +19,8 @@ import (
 
 func init() {
 	// TODO: config nodes add/remove
-	nodesCmd.AddCommand(addCmd())
-	nodesCmd.AddCommand(removeCmd())
+	nodesCmd.AddCommand(addNodesCmd())
+	nodesCmd.AddCommand(removeNodesCmd())
 	configCmd.AddCommand(nodesCmd)
 	// TODO: config peers add/remove
 	// TODO: config chain-id set
@@ -188,7 +188,7 @@ var nodesCmd = &cobra.Command{
 	Short: "Commands to configure the chain nodes",
 }
 
-func addCmd() *cobra.Command {
+func addNodesCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:     "add [chain-nodes]",
 		Aliases: []string{"a"},
@@ -229,7 +229,7 @@ func addCmd() *cobra.Command {
 	}
 }
 
-func removeCmd() *cobra.Command {
+func removeNodesCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:     "remove [chain-nodes]",
 		Aliases: []string{"r"},

--- a/cmd/horcrux/cmd/config.go
+++ b/cmd/horcrux/cmd/config.go
@@ -425,18 +425,16 @@ func setChainIdCmd() *cobra.Command {
 			}
 
 			stateDir := path.Join(home, "state")
-			files, err := ioutil.ReadDir(stateDir)
-			if err != nil {
+			pvOldPath := path.Join(stateDir, config.ChainID+"_priv_validator_state.json")
+			pvNewPath := path.Join(stateDir, args[0]+"_priv_validator_state.json")
+			shareOldPath := path.Join(stateDir, config.ChainID+"_share_sign_state.json")
+			shareNewPath := path.Join(stateDir, args[0]+"_share_sign_state.json")
+
+			if err = os.Rename(pvOldPath, pvNewPath); err != nil {
 				return err
 			}
-			for _, file := range files {
-				if strings.HasPrefix(file.Name(), config.ChainID) {
-					oldPath := path.Join(stateDir, file.Name())
-					newPath := path.Join(stateDir, strings.Replace(file.Name(), config.ChainID, args[0], 1))
-					if err = os.Rename(oldPath, newPath); err != nil {
-						return err
-					}
-				}
+			if err = os.Rename(shareOldPath, shareNewPath); err != nil {
+				return err
 			}
 
 			config.ChainID = args[0]

--- a/cmd/horcrux/cmd/config.go
+++ b/cmd/horcrux/cmd/config.go
@@ -27,8 +27,8 @@ func init() {
 	peersCmd.AddCommand(setSharesCmd())
 	configCmd.AddCommand(peersCmd)
 
-	chainIdCmd.AddCommand(setChainIdCmd())
-	configCmd.AddCommand(chainIdCmd)
+	chainIDCmd.AddCommand(setChainIDCmd())
+	configCmd.AddCommand(chainIDCmd)
 
 	configCmd.AddCommand(initCmd())
 	rootCmd.AddCommand(configCmd)
@@ -221,12 +221,12 @@ func addNodesCmd() *cobra.Command {
 			if len(diff) == 0 {
 				return errors.New("no new chain nodes in args")
 			}
-			tmpChainNodes := append(config.ChainNodes, diff...)
-			if err := validateChainNodes(tmpChainNodes); err != nil {
+			diff = append(config.ChainNodes, diff...)
+			if err := validateChainNodes(diff); err != nil {
 				return err
 			}
 
-			config.ChainNodes = tmpChainNodes
+			config.ChainNodes = diff
 			if err := writeConfigFile(path.Join(home, "config.yaml"), config); err != nil {
 				return err
 			}
@@ -330,12 +330,12 @@ func addPeersCmd() *cobra.Command {
 			if len(diff) == 0 {
 				return errors.New("no new peer nodes in args")
 			}
-			tmpPeers := append(config.CosignerConfig.Peers, diff...)
-			if err := validateCosignerPeers(tmpPeers, config.CosignerConfig.Shares); err != nil {
+			diff = append(config.CosignerConfig.Peers, diff...)
+			if err := validateCosignerPeers(diff, config.CosignerConfig.Shares); err != nil {
 				return err
 			}
 
-			config.CosignerConfig.Peers = tmpPeers
+			config.CosignerConfig.Peers = diff
 			if err := writeConfigFile(path.Join(home, "config.yaml"), config); err != nil {
 				return err
 			}
@@ -449,12 +449,12 @@ func diffSetCosignerPeer(setA, setB []CosignerPeer) (diff []CosignerPeer) {
 	return
 }
 
-var chainIdCmd = &cobra.Command{
+var chainIDCmd = &cobra.Command{
 	Use:   "chain-id",
 	Short: "Commands to configure the chain ID",
 }
 
-func setChainIdCmd() *cobra.Command {
+func setChainIDCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:     "set [chain-ID]",
 		Aliases: []string{"s"},

--- a/cmd/horcrux/cmd/config.go
+++ b/cmd/horcrux/cmd/config.go
@@ -177,7 +177,7 @@ func validateCosignerConfig(cfg *Config) error {
 	if _, err := url.Parse(cfg.CosignerConfig.P2PListen); err != nil {
 		return fmt.Errorf("failed to parse p2p listen address")
 	}
-	if err := validateCosignerPeers(&cfg.CosignerConfig.Peers); err != nil {
+	if err := validateCosignerPeers(cfg.CosignerConfig.Peers); err != nil {
 		return err
 	}
 	if err := validateChainNodes(cfg.ChainNodes); err != nil {
@@ -321,7 +321,7 @@ func addPeersCmd() *cobra.Command {
 				return errors.New("no new peer nodes specified in args")
 			}
 			config.CosignerConfig.Peers = append(config.CosignerConfig.Peers, diffSet...)
-			if err := validateCosignerPeers(&config.CosignerConfig.Peers); err != nil {
+			if err := validateCosignerPeers(config.CosignerConfig.Peers); err != nil {
 				return err
 			}
 
@@ -515,9 +515,9 @@ func readKeyShare() (*signer.CosignerKey, error) {
 	return &key, nil
 }
 
-func validateCosignerPeers(peers *[]CosignerPeer) error {
+func validateCosignerPeers(peers []CosignerPeer) error {
 	// Check IDs to make sure none are duplicated
-	if dupl := duplicatePeers(*peers); len(dupl) != 0 {
+	if dupl := duplicatePeers(peers); len(dupl) != 0 {
 		return fmt.Errorf("found duplicate share IDs in args: %v", dupl)
 	}
 
@@ -529,8 +529,7 @@ func validateCosignerPeers(peers *[]CosignerPeer) error {
 	}
 	for _, peer := range config.CosignerPeers() {
 		if peer.ID == key.ID {
-			fmt.Printf("skipping peer with share ID %v as local node is configured with that key share ID\n", key.ID)
-			*peers = diffSetCosignerPeer([]CosignerPeer{{peer.ID, peer.Address}}, config.CosignerConfig.Peers)
+			return fmt.Errorf("peer with share ID %v cannot be added", key.ID)
 		}
 	}
 	return nil

--- a/cmd/horcrux/cmd/config.go
+++ b/cmd/horcrux/cmd/config.go
@@ -26,8 +26,9 @@ func init() {
 	peersCmd.AddCommand(addPeersCmd())
 	peersCmd.AddCommand(removePeersCmd())
 	configCmd.AddCommand(peersCmd)
-	// TODO: config chain-id set
-	configCmd.AddCommand(setChainIdCmd)
+
+	chainIdCmd.AddCommand(setChainIdCmd())
+	configCmd.AddCommand(chainIdCmd)
 
 	configCmd.AddCommand(initCmd())
 	rootCmd.AddCommand(configCmd)
@@ -391,33 +392,40 @@ func diffSetCosignerPeer(setA, setB []CosignerPeer) (diffSet []CosignerPeer) {
 	return
 }
 
-var setChainIdCmd = &cobra.Command{
-	Use:     "set-chain-id [chain-ID]",
-	Aliases: []string{"id"},
-	Short:   "set the chain ID",
-	Long: "set the chain ID.\n\n" +
-		"[chain-id] is a string i.e.\n" +
-		"cosmoshub-4",
-	Args: cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) (err error) {
-		var home string // In root.go we end up with our
-		if homeDir != "" {
-			home = homeDir
-		} else {
-			home, _ = homedir.Dir()
-			home = path.Join(home, ".horcrux")
-		}
+var chainIdCmd = &cobra.Command{
+	Use:   "chain-id",
+	Short: "Commands to configure the chain ID",
+}
 
-		if _, err := os.Stat(homeDir); !os.IsNotExist(err) {
-			return fmt.Errorf("%s is not empty, check for existing configuration and clear path before trying again", homeDir)
-		}
+func setChainIdCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "set [chain-ID]",
+		Aliases: []string{"s"},
+		Short:   "set the chain ID",
+		Long: "set the chain ID.\n\n" +
+			"[chain-id] is a string i.e.\n" +
+			"cosmoshub-4",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			var home string // In root.go we end up with our
+			if homeDir != "" {
+				home = homeDir
+			} else {
+				home, _ = homedir.Dir()
+				home = path.Join(home, ".horcrux")
+			}
 
-		config.ChainID = args[0]
-		if err := writeConfigFile(path.Join(home, "config.yaml"), config); err != nil {
-			return err
-		}
-		return nil
-	},
+			if _, err := os.Stat(homeDir); !os.IsNotExist(err) {
+				return fmt.Errorf("%s is not empty, check for existing configuration and clear path before trying again", homeDir)
+			}
+
+			config.ChainID = args[0]
+			if err := writeConfigFile(path.Join(home, "config.yaml"), config); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
 }
 
 type Config struct {

--- a/cmd/horcrux/cmd/config.go
+++ b/cmd/horcrux/cmd/config.go
@@ -401,8 +401,8 @@ func setSharesCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:     "set-shares [num-shares]",
 		Aliases: []string{"shares"},
-		Short:   "Set the number of key shares",
-		Long: "Set the number of key shares.\n\n" +
+		Short:   "set the number of key shares",
+		Long: "set the number of key shares.\n\n" +
 			"[num-shares] is the number of generated key shares, used to limit the number of peers i.e." +
 			"3",
 		Args: cobra.ExactArgs(1),

--- a/cmd/horcrux/cmd/config.go
+++ b/cmd/horcrux/cmd/config.go
@@ -235,7 +235,7 @@ func removeCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			idx := exists(config.ChainNodes, args[0])
 			if idx == -1 {
-				return fmt.Errorf("chain node %v already exists", args[0])
+				return fmt.Errorf("chain node %v doesn't exist", args[0])
 			}
 			if err := validateChainNodes([]ChainNode{{PrivValAddr: args[0]}}); err != nil {
 				return err

--- a/cmd/horcrux/cmd/config.go
+++ b/cmd/horcrux/cmd/config.go
@@ -214,7 +214,7 @@ func addNodesCmd() *cobra.Command {
 				return err
 			}
 
-			newNodes := diffSet(config.ChainNodes, argNodes)
+			newNodes := diffSetChainNode(config.ChainNodes, argNodes)
 			if len(newNodes) == 0 {
 				return errors.New("no new chain nodes specified in args")
 			}
@@ -254,8 +254,7 @@ func removeNodesCmd() *cobra.Command {
 				return err
 			}
 
-			// truncatedNodes := removeNodesFromConfig(config.ChainNodes, argNodes)
-			truncatedNodes := diffSet(argNodes, config.ChainNodes)
+			truncatedNodes := diffSetChainNode(argNodes, config.ChainNodes)
 			if truncatedNodes == nil {
 				return errors.New("cannot remove all chain nodes from config, please leave at least one")
 			}
@@ -269,9 +268,9 @@ func removeNodesCmd() *cobra.Command {
 	}
 }
 
-// diffSet decribes the difference set of setA-setB, which are all values of setA
-// that are also part of setB.
-func diffSet(setA, setB []ChainNode) (newNodes []ChainNode) {
+// diffSetChainNode decribes the difference set of setA-setB, which are all ChainNodes
+// of setA that are also part of setB.
+func diffSetChainNode(setA, setB []ChainNode) (newNodes []ChainNode) {
 	for _, b := range setB {
 		found := false
 		for _, a := range setA {

--- a/cmd/horcrux/cmd/config.go
+++ b/cmd/horcrux/cmd/config.go
@@ -354,6 +354,8 @@ func removePeersCmd() *cobra.Command {
 				return fmt.Errorf("%s is not empty, check for existing configuration and clear path before trying again", homeDir)
 			}
 
+			// TODO: Instead of having to pass in the whole address and peer ID,
+			// just pass in the ID to remove a peer.
 			argPeers, err := peersFromFlag(args[0])
 			if err != nil {
 				return err

--- a/cmd/horcrux/cmd/config.go
+++ b/cmd/horcrux/cmd/config.go
@@ -411,19 +411,17 @@ func setChainIdCmd() *cobra.Command {
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			var home string // In root.go we end up with our
-			var stateDir string
 			if homeDir != "" {
 				home = homeDir
-				stateDir = path.Join(homeDir, "state")
 			} else {
 				home, _ = homedir.Dir()
 				home = path.Join(home, ".horcrux")
-				stateDir = path.Join(home, "state")
 			}
 			if _, err := os.Stat(homeDir); !os.IsNotExist(err) {
 				return fmt.Errorf("%s is not empty, check for existing configuration and clear path before trying again", homeDir)
 			}
 
+			stateDir := path.Join(home, "state")
 			pvOldPath := path.Join(stateDir, config.ChainID+"_priv_validator_state.json")
 			pvNewPath := path.Join(stateDir, args[0]+"_priv_validator_state.json")
 			shareOldPath := path.Join(stateDir, config.ChainID+"_share_sign_state.json")

--- a/cmd/horcrux/cmd/config.go
+++ b/cmd/horcrux/cmd/config.go
@@ -213,12 +213,11 @@ func addNodesCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-
-			newNodes := diffSetChainNode(config.ChainNodes, argNodes)
-			if len(newNodes) == 0 {
+			diffSet := diffSetChainNode(config.ChainNodes, argNodes)
+			if len(diffSet) == 0 {
 				return errors.New("no new chain nodes specified in args")
 			}
-			config.ChainNodes = append(config.ChainNodes, newNodes...)
+			config.ChainNodes = append(config.ChainNodes, diffSet...)
 
 			if err := writeConfigFile(path.Join(home, "config.yaml"), config); err != nil {
 				return err
@@ -253,12 +252,11 @@ func removeNodesCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-
-			truncatedNodes := diffSetChainNode(argNodes, config.ChainNodes)
-			if truncatedNodes == nil {
+			diffSet := diffSetChainNode(argNodes, config.ChainNodes)
+			if len(diffSet) == 0 {
 				return errors.New("cannot remove all chain nodes from config, please leave at least one")
 			}
-			config.ChainNodes = truncatedNodes
+			config.ChainNodes = diffSet
 
 			if err := writeConfigFile(path.Join(home, "config.yaml"), config); err != nil {
 				return err

--- a/cmd/horcrux/cmd/config.go
+++ b/cmd/horcrux/cmd/config.go
@@ -45,7 +45,7 @@ func initCmd() *cobra.Command {
 		Short:   "initalize configuration file and home directory if one doesn't already exist",
 		Long: "initalize configuration file, use flags for cosigner configuration.\n\n" +
 			"[chain-id] is the chain id of the chain to validate\n" +
-			"[chain-nodes] is a comma seperated array of chain node addresses i.e.\n" +
+			"[chain-nodes] is a comma separated array of chain node addresses i.e.\n" +
 			"tcp://chain-node-1:1234,tcp://chain-node-2:1234",
 		Args: cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
@@ -196,7 +196,7 @@ func addNodesCmd() *cobra.Command {
 		Aliases: []string{"a"},
 		Short:   "add chain node(s) to the cosigner's configuration",
 		Long: "add chain node(s) to the cosigner's configuration.\n\n" +
-			"[chain-nodes] is a comma seperated array of chain node addresses i.e.\n" +
+			"[chain-nodes] is a comma separated array of chain node addresses i.e.\n" +
 			"tcp://chain-node-1:1234,tcp://chain-node-2:1234",
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
@@ -235,7 +235,7 @@ func removeNodesCmd() *cobra.Command {
 		Aliases: []string{"r"},
 		Short:   "remove chain node(s) from the cosigner's configuration",
 		Long: "remove chain node(s) from the cosigner's configuration.\n\n" +
-			"[chain-nodes] is a comma seperated array of chain node addresses i.e.\n" +
+			"[chain-nodes] is a comma separated array of chain node addresses i.e.\n" +
 			"tcp://chain-node-1:1234,tcp://chain-node-2:1234",
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
@@ -298,7 +298,7 @@ func addPeersCmd() *cobra.Command {
 		Aliases: []string{"a"},
 		Short:   "add peer node(s) to the cosigner's configuration",
 		Long: "add peer node(s) to the cosigner's configuration.\n\n" +
-			"[peer-nodes] is a comma seperated array of peer node addresses i.e.\n" +
+			"[peer-nodes] is a comma separated array of peer node addresses i.e.\n" +
 			"tcp://peer-node-1:1234,tcp://peer-node-2:1234",
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
@@ -340,7 +340,7 @@ func removePeersCmd() *cobra.Command {
 		Aliases: []string{"r"},
 		Short:   "remove peer node(s) from the cosigner's configuration",
 		Long: "remove peer node(s) from the cosigner's configuration.\n\n" +
-			"[peer-node-ids] is a comma seperated array of peer node IDs i.e.\n" +
+			"[peer-node-ids] is a comma separated array of peer node IDs i.e.\n" +
 			"1,2",
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {

--- a/cmd/horcrux/cmd/config.go
+++ b/cmd/horcrux/cmd/config.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -18,11 +19,13 @@ import (
 )
 
 func init() {
-	// TODO: config nodes add/remove
 	nodesCmd.AddCommand(addNodesCmd())
 	nodesCmd.AddCommand(removeNodesCmd())
 	configCmd.AddCommand(nodesCmd)
-	// TODO: config peers add/remove
+
+	peersCmd.AddCommand(addPeersCmd())
+	peersCmd.AddCommand(removePeersCmd())
+	configCmd.AddCommand(peersCmd)
 	// TODO: config chain-id set
 	configCmd.AddCommand(setChainIdCmd)
 
@@ -268,7 +271,7 @@ func removeNodesCmd() *cobra.Command {
 
 // diffSetChainNode decribes the difference set of setA-setB, which are all ChainNodes
 // of setA that are also part of setB.
-func diffSetChainNode(setA, setB []ChainNode) (newNodes []ChainNode) {
+func diffSetChainNode(setA, setB []ChainNode) (diffSet []ChainNode) {
 	for _, b := range setB {
 		found := false
 		for _, a := range setA {
@@ -277,7 +280,110 @@ func diffSetChainNode(setA, setB []ChainNode) (newNodes []ChainNode) {
 			}
 		}
 		if !found {
-			newNodes = append(newNodes, b)
+			diffSet = append(diffSet, b)
+		}
+	}
+	return
+}
+
+var peersCmd = &cobra.Command{
+	Use:   "peers",
+	Short: "Commands to configure the peer nodes",
+}
+
+func addPeersCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "add [peer-nodes]",
+		Aliases: []string{"a"},
+		Short:   "add peer node(s) to the cosigner's configuration",
+		Long: "add peer node(s) to the cosigner's configuration.\n\n" +
+			"[peer-nodes] is a comma seperated array of peer node addresses i.e.\n" +
+			"tcp://peer-node-1:1234,tcp://peer-node-2:1234",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			var home string // In root.go we end up with our
+			if homeDir != "" {
+				home = homeDir
+			} else {
+				home, _ = homedir.Dir()
+				home = path.Join(home, ".horcrux")
+			}
+			if _, err := os.Stat(homeDir); !os.IsNotExist(err) {
+				return fmt.Errorf("%s is not empty, check for existing configuration and clear path before trying again", homeDir)
+			}
+
+			argPeers, err := peersFromFlag(args[0])
+			if err != nil {
+				return err
+			}
+			diffSet := diffSetCosignerPeer(config.CosignerConfig.Peers, argPeers)
+			if len(diffSet) == 0 {
+				return errors.New("no new peer nodes specified in args")
+			}
+			if err := validateCosignerPeers(diffSet); err != nil {
+				fmt.Println(err)
+			}
+			config.CosignerConfig.Peers = append(config.CosignerConfig.Peers, diffSet...)
+
+			if err := writeConfigFile(path.Join(home, "config.yaml"), config); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+}
+
+func removePeersCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "remove [peer-nodes]",
+		Aliases: []string{"r"},
+		Short:   "remove peer node(s) from the cosigner's configuration",
+		Long: "remove peer node(s) from the cosigner's configuration.\n\n" +
+			"[peer-nodes] is a comma seperated array of peer node addresses i.e.\n" +
+			"tcp://peer-node-1:1234,tcp://peer-node-2:1234",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			var home string // In root.go we end up with our
+			if homeDir != "" {
+				home = homeDir
+			} else {
+				home, _ = homedir.Dir()
+				home = path.Join(home, ".horcrux")
+			}
+			if _, err := os.Stat(homeDir); !os.IsNotExist(err) {
+				return fmt.Errorf("%s is not empty, check for existing configuration and clear path before trying again", homeDir)
+			}
+
+			argPeers, err := peersFromFlag(args[0])
+			if err != nil {
+				return err
+			}
+			diffSet := diffSetCosignerPeer(argPeers, config.CosignerConfig.Peers)
+			if len(diffSet) == 0 {
+				return errors.New("cannot remove all peer nodes from config, please leave at least one")
+			}
+			config.CosignerConfig.Peers = diffSet
+
+			if err := writeConfigFile(path.Join(home, "config.yaml"), config); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+}
+
+// diffSetCosignerPeer decribes the difference set of setA-setB, which are all
+// CosignerPeers of setA that are also part of setB.
+func diffSetCosignerPeer(setA, setB []CosignerPeer) (diffSet []CosignerPeer) {
+	for _, b := range setB {
+		found := false
+		for _, a := range setA {
+			if b == a {
+				found = true
+			}
+		}
+		if !found {
+			diffSet = append(diffSet, b)
 		}
 	}
 	return
@@ -353,10 +459,66 @@ type CosignerPeer struct {
 	P2PAddr string `json:"p2p-addr" yaml:"p2p-addr"`
 }
 
+func readKeyShare() (*signer.CosignerKey, error) {
+	// Read ID from local key share
+	var home string // In root.go we end up with our
+	if homeDir != "" {
+		home = homeDir
+	} else {
+		home, _ = homedir.Dir()
+		home = path.Join(home, ".horcrux")
+	}
+
+	if _, err := os.Stat(homeDir); !os.IsNotExist(err) {
+		return nil, fmt.Errorf("%s is not empty, check for existing configuration and clear path before trying again", homeDir)
+	}
+
+	file, err := os.Open(path.Join(home, "share.json"))
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	bz, err := ioutil.ReadAll(file)
+	if err != nil {
+		return nil, err
+	}
+	var key signer.CosignerKey
+	if err := json.Unmarshal(bz, &key); err != nil {
+		return nil, err
+	}
+	return &key, nil
+}
+
 func validateCosignerPeers(peers []CosignerPeer) error {
-	// TODO: check IDs to ensure none are duplicated and
-	// that the key share which is configured for the local node
-	// is the last remaining share
+	// Check IDs to make sure none are duplicated
+	encountered := make(map[int]string)
+	duplicates := []int{}
+	for _, peer := range peers {
+		if _, found := encountered[peer.ShareID]; !found {
+			encountered[peer.ShareID] = peer.P2PAddr
+		} else {
+			duplicates = append(duplicates, peer.ShareID)
+		}
+	}
+	if len(duplicates) != 0 {
+		return fmt.Errorf("found duplicates for peer IDs: %v", duplicates)
+	}
+
+	// TODO
+	// key, err := readKeyShare()
+	// if err != nil {
+	// 	return err
+	// }
+
+	// // Check that the key share which is configured for the local node
+	// // is the last remaining share
+	// for _, peer := range config.CosignerPeers() {
+	// 	if peer.ID == key.ID {
+	// 		return fmt.Errorf("conflict: local node's key share ID %v matches with another peer in the config, please make sure you're using the correct share", key.ID)
+	// 	}
+	// }
+
 	return nil
 }
 

--- a/cmd/horcrux/cmd/config.go
+++ b/cmd/horcrux/cmd/config.go
@@ -374,7 +374,7 @@ func removePeersCmd() *cobra.Command {
 	}
 }
 
-// diffSetCosignerPeer decribes the difference set of setA-setB, which are all
+// diffSetCosignerPeer returns the difference set of setA-setB, which includes all
 // CosignerPeers of setA that are also part of setB.
 func diffSetCosignerPeer(setA, setB []CosignerPeer) (diffSet []CosignerPeer) {
 	for _, b := range setB {

--- a/cmd/horcrux/cmd/config.go
+++ b/cmd/horcrux/cmd/config.go
@@ -315,11 +315,11 @@ func addPeersCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			diffSet := diffSetCosignerPeer(config.CosignerConfig.Peers, argPeers)
-			if len(diffSet) == 0 {
+			diff := diffSet(config.CosignerConfig.Peers, argPeers)
+			if len(diff) == 0 {
 				return errors.New("no new peer nodes specified in args")
 			}
-			config.CosignerConfig.Peers = append(config.CosignerConfig.Peers, diffSet...)
+			config.CosignerConfig.Peers = append(config.CosignerConfig.Peers, diff...)
 			if err := validateCosignerPeers(config.CosignerConfig.Peers); err != nil {
 				return err
 			}
@@ -363,11 +363,11 @@ func removePeersCmd() *cobra.Command {
 				}
 			}
 
-			diffSet := diffSetCosignerPeer(argPeers, config.CosignerConfig.Peers)
-			if len(diffSet) == 0 {
+			diff := diffSet(argPeers, config.CosignerConfig.Peers)
+			if len(diff) == 0 {
 				return errors.New("cannot remove all peer nodes from config, please leave at least one")
 			}
-			config.CosignerConfig.Peers = diffSet
+			config.CosignerConfig.Peers = diff
 
 			if err := writeConfigFile(path.Join(home, "config.yaml"), config); err != nil {
 				return err
@@ -377,9 +377,9 @@ func removePeersCmd() *cobra.Command {
 	}
 }
 
-// diffSetCosignerPeer returns the difference set of setA-setB, which includes all
+// diffSet returns the difference set of setA-setB, which includes all
 // CosignerPeers of setA that are also part of setB.
-func diffSetCosignerPeer(setA, setB []CosignerPeer) (diffSet []CosignerPeer) {
+func diffSet(setA, setB []CosignerPeer) (diff []CosignerPeer) {
 	for _, b := range setB {
 		found := false
 		for _, a := range setA {
@@ -388,7 +388,7 @@ func diffSetCosignerPeer(setA, setB []CosignerPeer) (diffSet []CosignerPeer) {
 			}
 		}
 		if !found {
-			diffSet = append(diffSet, b)
+			diff = append(diff, b)
 		}
 	}
 	return

--- a/cmd/horcrux/cmd/config.go
+++ b/cmd/horcrux/cmd/config.go
@@ -315,7 +315,7 @@ func addPeersCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			diff := diffSet(config.CosignerConfig.Peers, argPeers)
+			diff := diffSet(argPeers, config.CosignerConfig.Peers)
 			if len(diff) == 0 {
 				return errors.New("no new peer nodes specified in args")
 			}
@@ -363,7 +363,7 @@ func removePeersCmd() *cobra.Command {
 				}
 			}
 
-			diff := diffSet(argPeers, config.CosignerConfig.Peers)
+			diff := diffSet(config.CosignerConfig.Peers, argPeers)
 			if len(diff) == 0 {
 				return errors.New("cannot remove all peer nodes from config, please leave at least one")
 			}
@@ -377,18 +377,18 @@ func removePeersCmd() *cobra.Command {
 	}
 }
 
-// diffSet returns the difference set of setA-setB, which includes all
-// CosignerPeers of setA that are also part of setB.
+// diffSet returns the difference set of setA-setB.
+// Example: [1,2,3] & [2,3,4] => [1]
 func diffSet(setA, setB []CosignerPeer) (diff []CosignerPeer) {
-	for _, b := range setB {
+	for _, a := range setA {
 		found := false
-		for _, a := range setA {
-			if b == a {
+		for _, b := range setB {
+			if a == b {
 				found = true
 			}
 		}
 		if !found {
-			diff = append(diff, b)
+			diff = append(diff, a)
 		}
 	}
 	return

--- a/cmd/horcrux/cmd/config.go
+++ b/cmd/horcrux/cmd/config.go
@@ -422,6 +422,9 @@ func setSharesCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if err := validateCosignerPeers(config.CosignerConfig.Peers, numShares); err != nil {
+				return err
+			}
 
 			config.CosignerConfig.Shares = numShares
 			if err := writeConfigFile(path.Join(home, "config.yaml"), config); err != nil {

--- a/cmd/horcrux/cmd/config.go
+++ b/cmd/horcrux/cmd/config.go
@@ -411,15 +411,29 @@ func setChainIdCmd() *cobra.Command {
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			var home string // In root.go we end up with our
+			var stateDir string
 			if homeDir != "" {
 				home = homeDir
+				stateDir = path.Join(homeDir, "state")
 			} else {
 				home, _ = homedir.Dir()
 				home = path.Join(home, ".horcrux")
+				stateDir = path.Join(home, "state")
 			}
-
 			if _, err := os.Stat(homeDir); !os.IsNotExist(err) {
 				return fmt.Errorf("%s is not empty, check for existing configuration and clear path before trying again", homeDir)
+			}
+
+			pvOldPath := path.Join(stateDir, config.ChainID+"_priv_validator_state.json")
+			pvNewPath := path.Join(stateDir, args[0]+"_priv_validator_state.json")
+			shareOldPath := path.Join(stateDir, config.ChainID+"_share_sign_state.json")
+			shareNewPath := path.Join(stateDir, args[0]+"_share_sign_state.json")
+
+			if os.Rename(pvOldPath, pvNewPath); err != nil {
+				return err
+			}
+			if os.Rename(shareOldPath, shareNewPath); err != nil {
+				return err
 			}
 
 			config.ChainID = args[0]

--- a/cmd/horcrux/cmd/config.go
+++ b/cmd/horcrux/cmd/config.go
@@ -529,8 +529,7 @@ func validateCosignerPeers(peers *[]CosignerPeer) error {
 	}
 	for _, peer := range config.CosignerPeers() {
 		if peer.ID == key.ID {
-			// Remove the peer with the same share ID as the local node from the peers
-			fmt.Printf("local node is configured with key share ID %v, so a peer with that ID cannot be added anymore\n", key.ID)
+			fmt.Printf("skipping peer with share ID %v as local node is configured with that key share ID\n", key.ID)
 			*peers = diffSetCosignerPeer([]CosignerPeer{{peer.ID, peer.Address}}, config.CosignerConfig.Peers)
 		}
 	}

--- a/cmd/horcrux/cmd/config.go
+++ b/cmd/horcrux/cmd/config.go
@@ -24,6 +24,8 @@ func init() {
 	configCmd.AddCommand(nodesCmd)
 	// TODO: config peers add/remove
 	// TODO: config chain-id set
+	configCmd.AddCommand(setChainIdCmd)
+
 	configCmd.AddCommand(initCmd())
 	rootCmd.AddCommand(configCmd)
 }
@@ -287,6 +289,35 @@ func diff(nodes1, nodes2 []ChainNode) (diff []ChainNode) {
 		}
 	}
 	return
+}
+
+var setChainIdCmd = &cobra.Command{
+	Use:     "set-chain-id [chain-ID]",
+	Aliases: []string{"id"},
+	Short:   "set the chain ID",
+	Long: "set the chain ID.\n\n" +
+		"[chain-id] is a string i.e.\n" +
+		"cosmoshub-4",
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) (err error) {
+		var home string // In root.go we end up with our
+		if homeDir != "" {
+			home = homeDir
+		} else {
+			home, _ = homedir.Dir()
+			home = path.Join(home, ".horcrux")
+		}
+
+		if _, err := os.Stat(homeDir); !os.IsNotExist(err) {
+			return fmt.Errorf("%s is not empty, check for existing configuration and clear path before trying again", homeDir)
+		}
+
+		config.ChainID = args[0]
+		if err := writeConfigFile(path.Join(home, "config.yaml"), config); err != nil {
+			return err
+		}
+		return nil
+	},
 }
 
 type Config struct {

--- a/cmd/horcrux/cmd/config_test.go
+++ b/cmd/horcrux/cmd/config_test.go
@@ -32,6 +32,7 @@ func TestConfigInitCmd(t *testing.T) {
 				"tcp://10.168.0.1:1234",
 				"-c",
 				"-p", "tcp://10.168.1.2:2222|2,tcp://10.168.1.3:2222|3",
+				"-t", "2",
 				"--timeout", "1500ms",
 			},
 			expectErr: false,
@@ -44,6 +45,7 @@ func TestConfigInitCmd(t *testing.T) {
 				"://10.168.0.1:1234", // Missing/malformed protocol scheme
 				"-c",
 				"-p", "tcp://10.168.1.2:2222|2,tcp://10.168.1.3:2222|3",
+				"-t", "2",
 				"--timeout", "1500ms",
 			},
 			expectErr: true,
@@ -56,6 +58,7 @@ func TestConfigInitCmd(t *testing.T) {
 				"tcp://10.168.0.1:1234",
 				"-c",
 				"-p", "tcp://10.168.1.2:2222,tcp://10.168.1.3:2222", // Missing share IDs
+				"-t", "2",
 				"--timeout", "1500ms",
 			},
 			expectErr: true,
@@ -127,6 +130,7 @@ func TestConfigChainIDSetCmd(t *testing.T) {
 		"tcp://10.168.0.1:1234",
 		"-c",
 		"-p", "tcp://10.168.1.2:2222|2,tcp://10.168.1.3:2222|3",
+		"-t", "2",
 		"--timeout", "1500ms",
 	})
 	err = cmd.Execute()
@@ -185,6 +189,7 @@ func TestConfigNodesAddAndRemove(t *testing.T) {
 		"tcp://10.168.0.1:1234",
 		"-c",
 		"-p", "tcp://10.168.1.1:2222|1,tcp://10.168.1.2:2222|2",
+		"-t", "2",
 		"--timeout", "1500ms",
 	})
 	err = cmd.Execute()
@@ -329,6 +334,7 @@ func TestConfigPeersAddAndRemove(t *testing.T) {
 		"tcp://10.168.0.1:1234",
 		"-c",
 		"-p", "tcp://10.168.1.2:2222|2,tcp://10.168.1.3:2222|3,tcp://10.168.1.4:2222|4",
+		"-t", "2",
 		"--timeout", "1500ms",
 	})
 	err = cmd.Execute()

--- a/cmd/horcrux/cmd/config_test.go
+++ b/cmd/horcrux/cmd/config_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -102,7 +103,12 @@ func TestConfigInitCmd(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
-		os.RemoveAll(tmpHome)
+		files, err := filepath.Glob(tmpHome + "*")
+		require.NoError(t, err)
+
+		for _, file := range files {
+			os.RemoveAll(file)
+		}
 	})
 }
 
@@ -583,4 +589,8 @@ func TestDiffSetCosignerPeer(t *testing.T) {
 			require.Equal(t, diff, tc.expectDiff)
 		})
 	}
+}
+
+func TestSetShares(t *testing.T) {
+	// TODO: Implement logic
 }

--- a/cmd/horcrux/cmd/config_test.go
+++ b/cmd/horcrux/cmd/config_test.go
@@ -95,8 +95,7 @@ func TestConfigInitCmd(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
-		err := os.RemoveAll(tmpHome)
-		require.NoError(t, err)
+		os.RemoveAll(tmpHome)
 	})
 }
 
@@ -151,8 +150,7 @@ func TestConfigChainIDSetCmd(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
-		err := os.RemoveAll(tmpHome)
-		require.NoError(t, err)
+		os.RemoveAll(tmpHome)
 	})
 }
 
@@ -292,8 +290,7 @@ func TestConfigNodesAddAndRemove(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
-		err := os.RemoveAll(tmpHome)
-		require.NoError(t, err)
+		os.RemoveAll(tmpHome)
 	})
 }
 
@@ -434,8 +431,7 @@ func TestConfigPeersAddAndRemove(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
-		err := os.RemoveAll(tmpHome)
-		require.NoError(t, err)
+		os.RemoveAll(tmpHome)
 	})
 }
 

--- a/cmd/horcrux/cmd/config_test.go
+++ b/cmd/horcrux/cmd/config_test.go
@@ -1,0 +1,572 @@
+package cmd
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/strangelove-ventures/horcrux/signer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigInitCmd(t *testing.T) {
+	tmpHome := "/tmp/TestConfigInitCmd"
+	tmpConfig := path.Join(tmpHome, ".horcrux")
+	chainid := "horcrux-1"
+
+	err := os.Setenv("HOME", tmpHome)
+	require.NoError(t, err)
+	err = os.MkdirAll(tmpHome, 0777)
+	require.NoError(t, err)
+
+	tcs := []struct {
+		name      string
+		args      []string
+		expectErr bool
+	}{
+		{
+			name: "valid init",
+			args: []string{
+				chainid,
+				"tcp://10.168.0.1:1234",
+				"-c",
+				"-p", "tcp://10.168.1.2:2222|2,tcp://10.168.1.3:2222|3",
+				"--timeout", "1500ms",
+			},
+			expectErr: false,
+		},
+		{
+			name: "invalid chain-nodes",
+			args: []string{
+				chainid,
+				"://10.168.0.1:1234", // Missing/malformed protocol scheme
+				"-c",
+				"-p", "tcp://10.168.1.2:2222|2,tcp://10.168.1.3:2222|3",
+				"--timeout", "1500ms",
+			},
+			expectErr: true,
+		},
+		{
+			name: "invalid peer-nodes",
+			args: []string{
+				chainid,
+				"tcp://10.168.0.1:1234",
+				"-c",
+				"-p", "tcp://10.168.1.2:2222,tcp://10.168.1.3:2222", // Missing share IDs
+				"--timeout", "1500ms",
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := initCmd()
+			cmd.SetArgs(tc.args)
+			err = cmd.Execute()
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+
+				ss, err := signer.LoadSignState(path.Join(tmpConfig, "state", chainid+"_priv_validator_state.json"))
+				require.NoError(t, err)
+				require.Equal(t, int64(0), ss.Height)
+				require.Equal(t, int64(0), ss.Round)
+				require.Equal(t, int8(0), ss.Step)
+				require.Nil(t, ss.EphemeralPublic)
+				require.Nil(t, ss.Signature)
+				require.Nil(t, ss.SignBytes)
+
+				ss, err = signer.LoadSignState(path.Join(tmpConfig, "state", chainid+"_share_sign_state.json"))
+				require.NoError(t, err)
+				require.Equal(t, int64(0), ss.Height)
+				require.Equal(t, int64(0), ss.Round)
+				require.Equal(t, int8(0), ss.Step)
+				require.Nil(t, ss.EphemeralPublic)
+				require.Nil(t, ss.Signature)
+				require.Nil(t, ss.SignBytes)
+			}
+		})
+	}
+
+	t.Cleanup(func() {
+		err := os.RemoveAll(tmpHome)
+		require.NoError(t, err)
+	})
+}
+
+func TestConfigChainIDSetCmd(t *testing.T) {
+	tmpHome := "/tmp/TestConfigChainIDSetCmd"
+	chainid := "horcrux-1"
+
+	err := os.Setenv("HOME", tmpHome)
+	require.NoError(t, err)
+	err = os.MkdirAll(tmpHome, 0777)
+	require.NoError(t, err)
+
+	cmd := initCmd()
+	cmd.SetArgs([]string{
+		chainid,
+		"tcp://10.168.0.1:1234",
+		"-c",
+		"-p", "tcp://10.168.1.2:2222|2,tcp://10.168.1.3:2222|3",
+		"--timeout", "1500ms",
+	})
+	err = cmd.Execute()
+	require.NoError(t, err)
+
+	tcs := []struct {
+		name      string
+		args      []string
+		expectErr bool
+	}{
+		{
+			name:      "happy path",
+			args:      []string{"horcrux-2"},
+			expectErr: false,
+		},
+		{
+			name:      "missing chain-id",
+			args:      []string{},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := setChainIdCmd()
+			cmd.SetArgs(tc.args)
+			err := cmd.Execute()
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.args[0], config.ChainID)
+			}
+		})
+	}
+
+	t.Cleanup(func() {
+		err := os.RemoveAll(tmpHome)
+		require.NoError(t, err)
+	})
+}
+
+func TestConfigNodesAddAndRemove(t *testing.T) {
+	tmpHome := "/tmp/TestConfigNodesAddAndRemove"
+	chainid := "horcrux-1"
+
+	err := os.Setenv("HOME", tmpHome)
+	require.NoError(t, err)
+	err = os.MkdirAll(tmpHome, 0777)
+	require.NoError(t, err)
+
+	cmd := initCmd()
+	cmd.SetArgs([]string{
+		chainid,
+		"tcp://10.168.0.1:1234",
+		"-c",
+		"-p", "tcp://10.168.1.1:2222|1,tcp://10.168.1.2:2222|2",
+		"--timeout", "1500ms",
+	})
+	err = cmd.Execute()
+	require.NoError(t, err)
+
+	tcs := []struct {
+		name        string
+		cmd         *cobra.Command
+		args        []string
+		expectNodes []ChainNode
+		expectErr   bool
+	}{ // Do NOT change the order of the test cases!
+		{
+			name: "add single new node",
+			cmd:  addNodesCmd(),
+			args: []string{"tcp://10.168.0.2:1234"},
+			expectNodes: []ChainNode{
+				{PrivValAddr: "tcp://10.168.0.1:1234"},
+				{PrivValAddr: "tcp://10.168.0.2:1234"},
+			},
+			expectErr: false,
+		},
+		{
+			name: "remove single node",
+			cmd:  removeNodesCmd(),
+			args: []string{"tcp://10.168.0.2:1234"},
+			expectNodes: []ChainNode{
+				{PrivValAddr: "tcp://10.168.0.1:1234"},
+			},
+			expectErr: false,
+		},
+		{
+			name: "add multiple new nodes",
+			cmd:  addNodesCmd(),
+			args: []string{"tcp://10.168.0.2:1234,tcp://10.168.0.3:1234"},
+			expectNodes: []ChainNode{
+				{PrivValAddr: "tcp://10.168.0.1:1234"},
+				{PrivValAddr: "tcp://10.168.0.2:1234"},
+				{PrivValAddr: "tcp://10.168.0.3:1234"},
+			},
+			expectErr: false,
+		},
+		{
+			name: "remove multiple peers",
+			cmd:  removeNodesCmd(),
+			args: []string{"tcp://10.168.0.2:1234,tcp://10.168.0.3:1234"},
+			expectNodes: []ChainNode{
+				{PrivValAddr: "tcp://10.168.0.1:1234"},
+			},
+			expectErr: false,
+		},
+		{
+			name: "add invalid node",
+			cmd:  addNodesCmd(),
+			args: []string{"://10.168.0.3:1234"}, // Missing/malformed protocol scheme
+			expectNodes: []ChainNode{
+				{PrivValAddr: "tcp://10.168.0.1:1234"},
+			},
+			expectErr: true,
+		},
+		{
+			name: "remove invalid node",
+			cmd:  removeNodesCmd(),
+			args: []string{"://10.168.0.3:1234"}, // Missing/malformed protocol scheme
+			expectNodes: []ChainNode{
+				{PrivValAddr: "tcp://10.168.0.1:1234"},
+			},
+			expectErr: true,
+		},
+		{
+			name: "add existing node",
+			cmd:  addNodesCmd(),
+			args: []string{"tcp://10.168.0.1:1234"},
+			expectNodes: []ChainNode{
+				{PrivValAddr: "tcp://10.168.0.1:1234"},
+			},
+			expectErr: true,
+		},
+		{
+			name: "remove non-existent node",
+			cmd:  removeNodesCmd(),
+			args: []string{"tcp://10.168.0.99:1234"},
+			expectNodes: []ChainNode{
+				{PrivValAddr: "tcp://10.168.0.1:1234"},
+			},
+			expectErr: false,
+		},
+		{
+			name: "add one new and one existing node",
+			cmd:  addNodesCmd(),
+			args: []string{"tcp://10.168.0.1:1234,tcp://10.168.0.2:1234"},
+			expectNodes: []ChainNode{
+				{PrivValAddr: "tcp://10.168.0.1:1234"},
+				{PrivValAddr: "tcp://10.168.0.2:1234"},
+			},
+			expectErr: false,
+		},
+		{
+			name: "remove one existing and one non-existent node",
+			cmd:  removeNodesCmd(),
+			args: []string{"tcp://10.168.0.2:1234,tcp://10.168.0.3:1234"},
+			expectNodes: []ChainNode{
+				{PrivValAddr: "tcp://10.168.0.1:1234"},
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.cmd.SetArgs(tc.args)
+			err = tc.cmd.Execute()
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tc.expectNodes, config.ChainNodes)
+		})
+	}
+
+	t.Cleanup(func() {
+		err := os.RemoveAll(tmpHome)
+		require.NoError(t, err)
+	})
+}
+
+func TestConfigPeersAddAndRemove(t *testing.T) {
+	tmpHome := "/tmp/TestConfigPeersAddAndRemove"
+	chainid := "horcrux-1"
+
+	err := os.Setenv("HOME", tmpHome)
+	require.NoError(t, err)
+	err = os.MkdirAll(tmpHome, 0777)
+	require.NoError(t, err)
+
+	cmd := initCmd()
+	cmd.SetArgs([]string{
+		chainid,
+		"tcp://10.168.0.1:1234",
+		"-c",
+		"-p", "tcp://10.168.1.2:2222|2,tcp://10.168.1.3:2222|3,tcp://10.168.1.4:2222|4",
+		"--timeout", "1500ms",
+	})
+	err = cmd.Execute()
+	require.NoError(t, err)
+
+	tcs := []struct {
+		name        string
+		cmd         *cobra.Command
+		args        []string
+		expectPeers []CosignerPeer
+		expectErr   bool
+	}{ // Do NOT change the order of the test cases!
+		{
+			name: "remove single peer",
+			cmd:  removePeersCmd(),
+			args: []string{"4"},
+			expectPeers: []CosignerPeer{
+				{ShareID: 2, P2PAddr: "tcp://10.168.1.2:2222"},
+				{ShareID: 3, P2PAddr: "tcp://10.168.1.3:2222"},
+			},
+			expectErr: false,
+		},
+		{
+			name: "add single peer",
+			cmd:  addPeersCmd(),
+			args: []string{"tcp://10.168.1.4:2222|4"},
+			expectPeers: []CosignerPeer{
+				{ShareID: 2, P2PAddr: "tcp://10.168.1.2:2222"},
+				{ShareID: 3, P2PAddr: "tcp://10.168.1.3:2222"},
+				{ShareID: 4, P2PAddr: "tcp://10.168.1.4:2222"},
+			},
+			expectErr: false,
+		},
+		{
+			name: "remove multiple peers",
+			cmd:  removePeersCmd(),
+			args: []string{"3,4"},
+			expectPeers: []CosignerPeer{
+				{ShareID: 2, P2PAddr: "tcp://10.168.1.2:2222"},
+			},
+			expectErr: false,
+		},
+		{
+			name: "add multiple peers",
+			cmd:  addPeersCmd(),
+			args: []string{"tcp://10.168.1.3:2222|3,tcp://10.168.1.4:2222|4"},
+			expectPeers: []CosignerPeer{
+				{ShareID: 2, P2PAddr: "tcp://10.168.1.2:2222"},
+				{ShareID: 3, P2PAddr: "tcp://10.168.1.3:2222"},
+				{ShareID: 4, P2PAddr: "tcp://10.168.1.4:2222"},
+			},
+			expectErr: false,
+		},
+		{
+			name: "remove non-existent peer",
+			cmd:  removePeersCmd(),
+			args: []string{"1"},
+			expectPeers: []CosignerPeer{
+				{ShareID: 2, P2PAddr: "tcp://10.168.1.2:2222"},
+				{ShareID: 3, P2PAddr: "tcp://10.168.1.3:2222"},
+				{ShareID: 4, P2PAddr: "tcp://10.168.1.4:2222"},
+			},
+			expectErr: false,
+		},
+		{
+			name: "add existing peer",
+			cmd:  addPeersCmd(),
+			args: []string{"tcp://10.168.1.3:2222|3"},
+			expectPeers: []CosignerPeer{
+				{ShareID: 2, P2PAddr: "tcp://10.168.1.2:2222"},
+				{ShareID: 3, P2PAddr: "tcp://10.168.1.3:2222"},
+				{ShareID: 4, P2PAddr: "tcp://10.168.1.4:2222"},
+			},
+			expectErr: true,
+		},
+		{
+			name: "remove one existing and one non-existent peer",
+			cmd:  removePeersCmd(),
+			args: []string{"1,4"},
+			expectPeers: []CosignerPeer{
+				{ShareID: 2, P2PAddr: "tcp://10.168.1.2:2222"},
+				{ShareID: 3, P2PAddr: "tcp://10.168.1.3:2222"},
+			},
+			expectErr: false,
+		},
+		{
+			name: "add one non-existent and one existing peer",
+			cmd:  addPeersCmd(),
+			args: []string{"tcp://10.168.1.3:2222|3,tcp://10.168.1.4:2222|4"},
+			expectPeers: []CosignerPeer{
+				{ShareID: 2, P2PAddr: "tcp://10.168.1.2:2222"},
+				{ShareID: 3, P2PAddr: "tcp://10.168.1.3:2222"},
+				{ShareID: 4, P2PAddr: "tcp://10.168.1.4:2222"},
+			},
+			expectErr: false,
+		},
+		{
+			name: "add peer with ID out of range",
+			cmd:  addPeersCmd(),
+			args: []string{"tcp://10.168.1.5:2222|5"},
+			expectPeers: []CosignerPeer{
+				{ShareID: 2, P2PAddr: "tcp://10.168.1.2:2222"},
+				{ShareID: 3, P2PAddr: "tcp://10.168.1.3:2222"},
+				{ShareID: 4, P2PAddr: "tcp://10.168.1.4:2222"},
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.cmd.SetArgs(tc.args)
+			err = tc.cmd.Execute()
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tc.expectPeers, config.CosignerConfig.Peers)
+		})
+	}
+
+	t.Cleanup(func() {
+		err := os.RemoveAll(tmpHome)
+		require.NoError(t, err)
+	})
+}
+
+func TestDiffSetChainNode(t *testing.T) {
+	tcs := []struct {
+		name       string
+		setA       []ChainNode
+		setB       []ChainNode
+		expectDiff []ChainNode
+	}{
+		{
+			name: "1 new, no overlap",
+			setA: []ChainNode{
+				{PrivValAddr: "tcp://10.168.0.1:1234"},
+			},
+			setB: []ChainNode{
+				{PrivValAddr: "tcp://10.168.0.2:1234"},
+			},
+			expectDiff: []ChainNode{
+				{PrivValAddr: "tcp://10.168.0.1:1234"},
+			},
+		},
+		{
+			name: "1 new, 1 overlap chain node",
+			setA: []ChainNode{
+				{PrivValAddr: "tcp://10.168.0.1:1234"},
+				{PrivValAddr: "tcp://10.168.0.2:1234"},
+			},
+			setB: []ChainNode{
+				{PrivValAddr: "tcp://10.168.0.2:1234"},
+				{PrivValAddr: "tcp://10.168.0.3:1234"},
+			},
+			expectDiff: []ChainNode{
+				{PrivValAddr: "tcp://10.168.0.1:1234"},
+			},
+		},
+		{
+			name: "0 new, partial overlap",
+			setA: []ChainNode{
+				{PrivValAddr: "tcp://10.168.0.1:1234"},
+			},
+			setB: []ChainNode{
+				{PrivValAddr: "tcp://10.168.0.1:1234"},
+				{PrivValAddr: "tcp://10.168.0.2:1234"},
+			},
+			expectDiff: nil,
+		},
+		{
+			name: "0 new, all overlap",
+			setA: []ChainNode{
+				{PrivValAddr: "tcp://10.168.0.1:1234"},
+				{PrivValAddr: "tcp://10.168.0.2:1234"},
+			},
+			setB: []ChainNode{
+				{PrivValAddr: "tcp://10.168.0.1:1234"},
+				{PrivValAddr: "tcp://10.168.0.2:1234"},
+			},
+			expectDiff: nil,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			diff := diffSetChainNode(tc.setA, tc.setB)
+			require.Equal(t, diff, tc.expectDiff)
+		})
+	}
+}
+
+func TestDiffSetCosignerPeer(t *testing.T) {
+	tcs := []struct {
+		name       string
+		setA       []CosignerPeer
+		setB       []CosignerPeer
+		expectDiff []CosignerPeer
+	}{
+		{
+			name: "1 new, no overlap",
+			setA: []CosignerPeer{
+				{ShareID: 1, P2PAddr: "tcp://10.168.1.1:2222"},
+			},
+			setB: []CosignerPeer{
+				{ShareID: 2, P2PAddr: "tcp://10.168.1.2:2222"},
+			},
+			expectDiff: []CosignerPeer{
+				{ShareID: 1, P2PAddr: "tcp://10.168.1.1:2222"},
+			},
+		},
+		{
+			name: "1 new, 1 overlap peer node",
+			setA: []CosignerPeer{
+				{ShareID: 1, P2PAddr: "tcp://10.168.1.1:2222"},
+				{ShareID: 2, P2PAddr: "tcp://10.168.1.2:2222"},
+			},
+			setB: []CosignerPeer{
+				{ShareID: 2, P2PAddr: "tcp://10.168.1.2:2222"},
+				{ShareID: 3, P2PAddr: "tcp://10.168.1.3:2222"},
+			},
+			expectDiff: []CosignerPeer{
+				{ShareID: 1, P2PAddr: "tcp://10.168.1.1:2222"},
+			},
+		},
+		{
+			name: "0 new, partial overlap",
+			setA: []CosignerPeer{
+				{ShareID: 1, P2PAddr: "tcp://10.168.1.1:2222"},
+			},
+			setB: []CosignerPeer{
+				{ShareID: 1, P2PAddr: "tcp://10.168.1.1:2222"},
+				{ShareID: 2, P2PAddr: "tcp://10.168.1.2:2222"},
+			},
+			expectDiff: nil,
+		},
+		{
+			name: "0 new, all overlap",
+			setA: []CosignerPeer{
+				{ShareID: 1, P2PAddr: "tcp://10.168.1.1:2222"},
+				{ShareID: 2, P2PAddr: "tcp://10.168.1.2:2222"},
+			},
+			setB: []CosignerPeer{
+				{ShareID: 1, P2PAddr: "tcp://10.168.1.1:2222"},
+				{ShareID: 2, P2PAddr: "tcp://10.168.1.2:2222"},
+			},
+			expectDiff: nil,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			diff := diffSetCosignerPeer(tc.setA, tc.setB)
+			require.Equal(t, diff, tc.expectDiff)
+		})
+	}
+}

--- a/cmd/horcrux/cmd/config_test.go
+++ b/cmd/horcrux/cmd/config_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -66,8 +67,10 @@ func TestConfigInitCmd(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			cmd := initCmd()
+			cmd.SetOutput(ioutil.Discard)
 			cmd.SetArgs(tc.args)
 			err = cmd.Execute()
+
 			if tc.expectErr {
 				require.Error(t, err)
 			} else {
@@ -108,6 +111,7 @@ func TestConfigChainIDSetCmd(t *testing.T) {
 	require.NoError(t, err)
 
 	cmd := initCmd()
+	cmd.SetOutput(ioutil.Discard)
 	cmd.SetArgs([]string{
 		chainID,
 		"tcp://10.168.0.1:1234",
@@ -138,8 +142,10 @@ func TestConfigChainIDSetCmd(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			cmd := setChainIDCmd()
+			cmd.SetOutput(ioutil.Discard)
 			cmd.SetArgs(tc.args)
 			err := cmd.Execute()
+
 			if tc.expectErr {
 				require.Error(t, err)
 			} else {
@@ -163,6 +169,7 @@ func TestConfigNodesAddAndRemove(t *testing.T) {
 	require.NoError(t, err)
 
 	cmd := initCmd()
+	cmd.SetOutput(ioutil.Discard)
 	cmd.SetArgs([]string{
 		chainID,
 		"tcp://10.168.0.1:1234",
@@ -278,13 +285,16 @@ func TestConfigNodesAddAndRemove(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
+			tc.cmd.SetOutput(ioutil.Discard)
 			tc.cmd.SetArgs(tc.args)
 			err = tc.cmd.Execute()
+
 			if tc.expectErr {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
 			}
+
 			require.Equal(t, tc.expectNodes, config.ChainNodes)
 		})
 	}
@@ -303,6 +313,7 @@ func TestConfigPeersAddAndRemove(t *testing.T) {
 	require.NoError(t, err)
 
 	cmd := initCmd()
+	cmd.SetOutput(ioutil.Discard)
 	cmd.SetArgs([]string{
 		chainID,
 		"tcp://10.168.0.1:1234",
@@ -419,13 +430,16 @@ func TestConfigPeersAddAndRemove(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
+			tc.cmd.SetOutput(ioutil.Discard)
 			tc.cmd.SetArgs(tc.args)
 			err = tc.cmd.Execute()
+
 			if tc.expectErr {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
 			}
+
 			require.Equal(t, tc.expectPeers, config.CosignerConfig.Peers)
 		})
 	}

--- a/cmd/horcrux/cmd/config_test.go
+++ b/cmd/horcrux/cmd/config_test.go
@@ -10,10 +10,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	chainID = "horcrux-1"
+)
+
 func TestConfigInitCmd(t *testing.T) {
 	tmpHome := "/tmp/TestConfigInitCmd"
 	tmpConfig := path.Join(tmpHome, ".horcrux")
-	chainid := "horcrux-1"
 
 	err := os.Setenv("HOME", tmpHome)
 	require.NoError(t, err)
@@ -28,7 +31,7 @@ func TestConfigInitCmd(t *testing.T) {
 		{
 			name: "valid init",
 			args: []string{
-				chainid,
+				chainID,
 				"tcp://10.168.0.1:1234",
 				"-c",
 				"-p", "tcp://10.168.1.2:2222|2,tcp://10.168.1.3:2222|3",
@@ -39,7 +42,7 @@ func TestConfigInitCmd(t *testing.T) {
 		{
 			name: "invalid chain-nodes",
 			args: []string{
-				chainid,
+				chainID,
 				"://10.168.0.1:1234", // Missing/malformed protocol scheme
 				"-c",
 				"-p", "tcp://10.168.1.2:2222|2,tcp://10.168.1.3:2222|3",
@@ -50,7 +53,7 @@ func TestConfigInitCmd(t *testing.T) {
 		{
 			name: "invalid peer-nodes",
 			args: []string{
-				chainid,
+				chainID,
 				"tcp://10.168.0.1:1234",
 				"-c",
 				"-p", "tcp://10.168.1.2:2222,tcp://10.168.1.3:2222", // Missing share IDs
@@ -70,7 +73,7 @@ func TestConfigInitCmd(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 
-				ss, err := signer.LoadSignState(path.Join(tmpConfig, "state", chainid+"_priv_validator_state.json"))
+				ss, err := signer.LoadSignState(path.Join(tmpConfig, "state", chainID+"_priv_validator_state.json"))
 				require.NoError(t, err)
 				require.Equal(t, int64(0), ss.Height)
 				require.Equal(t, int64(0), ss.Round)
@@ -79,7 +82,7 @@ func TestConfigInitCmd(t *testing.T) {
 				require.Nil(t, ss.Signature)
 				require.Nil(t, ss.SignBytes)
 
-				ss, err = signer.LoadSignState(path.Join(tmpConfig, "state", chainid+"_share_sign_state.json"))
+				ss, err = signer.LoadSignState(path.Join(tmpConfig, "state", chainID+"_share_sign_state.json"))
 				require.NoError(t, err)
 				require.Equal(t, int64(0), ss.Height)
 				require.Equal(t, int64(0), ss.Round)
@@ -99,7 +102,6 @@ func TestConfigInitCmd(t *testing.T) {
 
 func TestConfigChainIDSetCmd(t *testing.T) {
 	tmpHome := "/tmp/TestConfigChainIDSetCmd"
-	chainid := "horcrux-1"
 
 	err := os.Setenv("HOME", tmpHome)
 	require.NoError(t, err)
@@ -108,7 +110,7 @@ func TestConfigChainIDSetCmd(t *testing.T) {
 
 	cmd := initCmd()
 	cmd.SetArgs([]string{
-		chainid,
+		chainID,
 		"tcp://10.168.0.1:1234",
 		"-c",
 		"-p", "tcp://10.168.1.2:2222|2,tcp://10.168.1.3:2222|3",
@@ -136,7 +138,7 @@ func TestConfigChainIDSetCmd(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd := setChainIdCmd()
+			cmd := setChainIDCmd()
 			cmd.SetArgs(tc.args)
 			err := cmd.Execute()
 			if tc.expectErr {
@@ -156,7 +158,6 @@ func TestConfigChainIDSetCmd(t *testing.T) {
 
 func TestConfigNodesAddAndRemove(t *testing.T) {
 	tmpHome := "/tmp/TestConfigNodesAddAndRemove"
-	chainid := "horcrux-1"
 
 	err := os.Setenv("HOME", tmpHome)
 	require.NoError(t, err)
@@ -165,7 +166,7 @@ func TestConfigNodesAddAndRemove(t *testing.T) {
 
 	cmd := initCmd()
 	cmd.SetArgs([]string{
-		chainid,
+		chainID,
 		"tcp://10.168.0.1:1234",
 		"-c",
 		"-p", "tcp://10.168.1.1:2222|1,tcp://10.168.1.2:2222|2",
@@ -298,7 +299,6 @@ func TestConfigNodesAddAndRemove(t *testing.T) {
 
 func TestConfigPeersAddAndRemove(t *testing.T) {
 	tmpHome := "/tmp/TestConfigPeersAddAndRemove"
-	chainid := "horcrux-1"
 
 	err := os.Setenv("HOME", tmpHome)
 	require.NoError(t, err)
@@ -307,7 +307,7 @@ func TestConfigPeersAddAndRemove(t *testing.T) {
 
 	cmd := initCmd()
 	cmd.SetArgs([]string{
-		chainid,
+		chainID,
 		"tcp://10.168.0.1:1234",
 		"-c",
 		"-p", "tcp://10.168.1.2:2222|2,tcp://10.168.1.3:2222|3,tcp://10.168.1.4:2222|4",

--- a/cmd/horcrux/cmd/config_test.go
+++ b/cmd/horcrux/cmd/config_test.go
@@ -17,20 +17,15 @@ const (
 
 func TestConfigInitCmd(t *testing.T) {
 	tmpHome := "/tmp/TestConfigInitCmd"
-	tmpConfig := path.Join(tmpHome, ".horcrux")
-
-	err := os.Setenv("HOME", tmpHome)
-	require.NoError(t, err)
-	err = os.MkdirAll(tmpHome, 0777)
-	require.NoError(t, err)
-
 	tcs := []struct {
 		name      string
+		home      string
 		args      []string
 		expectErr bool
 	}{
 		{
 			name: "valid init",
+			home: tmpHome + "_valid_init",
 			args: []string{
 				chainID,
 				"tcp://10.168.0.1:1234",
@@ -42,6 +37,7 @@ func TestConfigInitCmd(t *testing.T) {
 		},
 		{
 			name: "invalid chain-nodes",
+			home: tmpHome + "_invalid_chain-nodes",
 			args: []string{
 				chainID,
 				"://10.168.0.1:1234", // Missing/malformed protocol scheme
@@ -53,6 +49,7 @@ func TestConfigInitCmd(t *testing.T) {
 		},
 		{
 			name: "invalid peer-nodes",
+			home: tmpHome + "_invalid_peer-nodes",
 			args: []string{
 				chainID,
 				"tcp://10.168.0.1:1234",
@@ -66,6 +63,13 @@ func TestConfigInitCmd(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
+			tmpConfig := path.Join(tc.home, ".horcrux")
+
+			err := os.Setenv("HOME", tc.home)
+			require.NoError(t, err)
+			err = os.MkdirAll(tc.home, 0777)
+			require.NoError(t, err)
+
 			cmd := initCmd()
 			cmd.SetOutput(ioutil.Discard)
 			cmd.SetArgs(tc.args)

--- a/cmd/horcrux/cmd/cosigner.go
+++ b/cmd/horcrux/cmd/cosigner.go
@@ -27,7 +27,7 @@ var cosignerCmd = &cobra.Command{
 func StartCosignerCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "start",
-		Short: "start cosigner process",
+		Short: "Start cosigner process",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			err = validateCosignerConfig(config)

--- a/cmd/horcrux/cmd/key2shares.go
+++ b/cmd/horcrux/cmd/key2shares.go
@@ -34,7 +34,7 @@ func CreateCosignerSharesCmd() *cobra.Command {
 		Use:     "create-shares [priv_validator.json] [threshold] [shares]",
 		Aliases: []string{"shard", "shares"},
 		Args:    validateCreateCosignerShares,
-		Short:   "create  cosigner shares",
+		Short:   "Create  cosigner shares",
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			threshold, _ := strconv.ParseInt(args[1], 10, 64)
 			numShares, _ := strconv.ParseInt(args[2], 10, 64)

--- a/cmd/horcrux/cmd/main_test.go
+++ b/cmd/horcrux/cmd/main_test.go
@@ -1,0 +1,16 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+
+	"github.com/mitchellh/go-homedir"
+)
+
+func TestMain(m *testing.M) {
+	// Disable caching mechanism from go-homedir for all "cmd" package tests.
+	homedir.DisableCache = true
+	code := m.Run()
+	homedir.DisableCache = false
+	os.Exit(code)
+}

--- a/cmd/horcrux/cmd/root.go
+++ b/cmd/horcrux/cmd/root.go
@@ -30,7 +30,7 @@ func Execute() {
 
 func init() {
 	cobra.OnInitialize(initConfig)
-	rootCmd.PersistentFlags().StringVar(&homeDir, "home", "", "directory for config and data (default is $HOME/.horcrux)")
+	rootCmd.PersistentFlags().StringVar(&homeDir, "home", "", "Directory for config and data (default is $HOME/.horcrux)")
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/horcrux/cmd/signer.go
+++ b/cmd/horcrux/cmd/signer.go
@@ -27,7 +27,7 @@ var signerCmd = &cobra.Command{
 func StartSignerCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "start",
-		Short: "start single signer process",
+		Short: "Start single signer process",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			err = validateSingleSignerConfig(config)

--- a/cmd/horcrux/cmd/state.go
+++ b/cmd/horcrux/cmd/state.go
@@ -70,6 +70,9 @@ func resetPvCmd() *cobra.Command {
 		Short:   "Reset the priv validator state",
 		Args:    cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// TODO: Resetting the priv_validator_state.json should only be allowed if
+			// the signer is not running.
+
 			var stateDir string // In root.go we end up with our
 			if homeDir != "" {
 				stateDir = path.Join(homeDir, "state")
@@ -144,6 +147,9 @@ func resetShareCmd() *cobra.Command {
 		Short:   "Reset the share sign state",
 		Args:    cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// TODO: Resetting the share_sign_state.json should only be allowed if the
+			// signer is not running.
+
 			var stateDir string // In root.go we end up with our
 			if homeDir != "" {
 				stateDir = path.Join(homeDir, "state")

--- a/cmd/horcrux/cmd/state.go
+++ b/cmd/horcrux/cmd/state.go
@@ -2,8 +2,10 @@ package cmd
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path"
 
 	"github.com/mitchellh/go-homedir"
@@ -70,8 +72,11 @@ func resetPvCmd() *cobra.Command {
 		Short:   "Reset the priv validator state",
 		Args:    cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// TODO: Resetting the priv_validator_state.json should only be allowed if
-			// the signer is not running.
+			// Resetting the priv_validator_state.json should only be allowed if the
+			// signer is not running.
+			if isRunning() {
+				return errors.New("cannot modify priv validator state while horcrux is running")
+			}
 
 			var stateDir string // In root.go we end up with our
 			if homeDir != "" {
@@ -147,8 +152,11 @@ func resetShareCmd() *cobra.Command {
 		Short:   "Reset the share sign state",
 		Args:    cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// TODO: Resetting the share_sign_state.json should only be allowed if the
+			// Resetting the share_sign_state.json should only be allowed if the
 			// signer is not running.
+			if isRunning() {
+				return errors.New("cannot modify priv validator state while horcrux is running")
+			}
 
 			var stateDir string // In root.go we end up with our
 			if homeDir != "" {
@@ -180,6 +188,12 @@ func resetShareCmd() *cobra.Command {
 	}
 	cmd.Flags().Int64("height", 0, "set to reset the share sign state to the specified height")
 	return cmd
+}
+
+func isRunning() bool {
+	pipe := "ps -ax | pgrep horcrux"
+	bz, _ := exec.Command("bash", "-c", pipe).Output()
+	return len(bz) != 0
 }
 
 func printSignState(ss signer.SignState) {

--- a/cmd/horcrux/cmd/state.go
+++ b/cmd/horcrux/cmd/state.go
@@ -1,0 +1,196 @@
+package cmd
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/mitchellh/go-homedir"
+	"github.com/spf13/cobra"
+	"github.com/strangelove-ventures/horcrux/signer"
+)
+
+func init() {
+	pvCmd.AddCommand(showPvCmd())
+	pvCmd.AddCommand(resetPvCmd())
+	stateCmd.AddCommand(pvCmd)
+
+	shareCmd.AddCommand(showShareCmd())
+	shareCmd.AddCommand(resetShareCmd())
+	stateCmd.AddCommand(shareCmd)
+
+	rootCmd.AddCommand(stateCmd)
+}
+
+var stateCmd = &cobra.Command{
+	Use:   "state",
+	Short: "Commands to configure the state",
+}
+
+var pvCmd = &cobra.Command{
+	Use:   "pv",
+	Short: "Commands to configure the priv validator state",
+}
+
+func showPvCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "show",
+		Aliases: []string{"s"},
+		Short:   "Show the priv validator state",
+		Args:    cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var stateDir string // In root.go we end up with our
+			if homeDir != "" {
+				stateDir = path.Join(homeDir, "state")
+			} else {
+				home, _ := homedir.Dir()
+				stateDir = path.Join(home, ".horcrux", "state")
+			}
+			if _, err := os.Stat(homeDir); !os.IsNotExist(err) {
+				return fmt.Errorf("%s is not empty, check for existing configuration and clear path before trying again", homeDir)
+			}
+
+			stateFilePath := path.Join(stateDir, config.ChainID+"_priv_validator_state.json")
+			ss, err := signer.LoadSignState(stateFilePath)
+			if err != nil {
+				return err
+			}
+
+			printSignState(ss)
+			return nil
+		},
+	}
+}
+
+func resetPvCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "reset",
+		Aliases: []string{"r"},
+		Short:   "Reset the priv validator state",
+		Args:    cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var stateDir string // In root.go we end up with our
+			if homeDir != "" {
+				stateDir = path.Join(homeDir, "state")
+			} else {
+				home, _ := homedir.Dir()
+				stateDir = path.Join(home, ".horcrux", "state")
+			}
+			if _, err := os.Stat(homeDir); !os.IsNotExist(err) {
+				return fmt.Errorf("%s is not empty, check for existing configuration and clear path before trying again", homeDir)
+			}
+
+			h, err := cmd.Flags().GetInt64("height")
+			if err != nil {
+				return err
+			}
+
+			stateFilePath := path.Join(stateDir, config.ChainID+"_priv_validator_state.json")
+			ss, err := signer.LoadSignState(stateFilePath)
+			if err != nil {
+				return err
+			}
+
+			ss.Height, ss.Round, ss.Step = h, 0, 0
+			ss.EphemeralPublic, ss.Signature, ss.SignBytes = nil, nil, nil
+			ss.Save()
+			return nil
+		},
+	}
+	cmd.Flags().Int64("height", 0, "set to reset the priv validator state to the specified height")
+	return cmd
+}
+
+var shareCmd = &cobra.Command{
+	Use:   "share",
+	Short: "Commands to configure the share sign state",
+}
+
+func showShareCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "show",
+		Aliases: []string{"s"},
+		Short:   "Show the share sign state",
+		Args:    cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var stateDir string // In root.go we end up with our
+			if homeDir != "" {
+				stateDir = path.Join(homeDir, "state")
+			} else {
+				home, _ := homedir.Dir()
+				stateDir = path.Join(home, ".horcrux", "state")
+			}
+			if _, err := os.Stat(homeDir); !os.IsNotExist(err) {
+				return fmt.Errorf("%s is not empty, check for existing configuration and clear path before trying again", homeDir)
+			}
+
+			stateFilePath := path.Join(stateDir, config.ChainID+"_share_sign_state.json")
+			ss, err := signer.LoadSignState(stateFilePath)
+			if err != nil {
+				return err
+			}
+
+			printSignState(ss)
+			return nil
+		},
+	}
+}
+
+func resetShareCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "reset",
+		Aliases: []string{"r"},
+		Short:   "Reset the share sign state",
+		Args:    cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var stateDir string // In root.go we end up with our
+			if homeDir != "" {
+				stateDir = path.Join(homeDir, "state")
+			} else {
+				home, _ := homedir.Dir()
+				stateDir = path.Join(home, ".horcrux", "state")
+			}
+			if _, err := os.Stat(homeDir); !os.IsNotExist(err) {
+				return fmt.Errorf("%s is not empty, check for existing configuration and clear path before trying again", homeDir)
+			}
+
+			h, err := cmd.Flags().GetInt64("height")
+			if err != nil {
+				return err
+			}
+
+			stateFilePath := path.Join(stateDir, config.ChainID+"_share_sign_state.json")
+			ss, err := signer.LoadSignState(stateFilePath)
+			if err != nil {
+				return err
+			}
+
+			ss.Height, ss.Round, ss.Step = h, 0, 0
+			ss.EphemeralPublic, ss.Signature, ss.SignBytes = nil, nil, nil
+			ss.Save()
+			return nil
+		},
+	}
+	cmd.Flags().Int64("height", 0, "set to reset the share sign state to the specified height")
+	return cmd
+}
+
+func printSignState(ss signer.SignState) {
+	fmt.Printf("Height:    %v\n"+
+		"Round:     %v\n"+
+		"Step:      %v\n",
+		ss.Height, ss.Round, ss.Step)
+
+	if ss.EphemeralPublic != nil {
+		encPub := base64.StdEncoding.EncodeToString(ss.EphemeralPublic)
+		fmt.Println("Ephemeral Public Key:", encPub)
+	}
+	if ss.Signature != nil {
+		encSig := base64.StdEncoding.EncodeToString(ss.Signature)
+		fmt.Println("Signature:", encSig)
+	}
+	if ss.SignBytes != nil {
+		fmt.Println("SignBytes:", ss.SignBytes)
+	}
+}

--- a/cmd/horcrux/cmd/state.go
+++ b/cmd/horcrux/cmd/state.go
@@ -15,8 +15,8 @@ import (
 )
 
 func init() {
-	stateCmd.AddCommand(showCmd())
-	stateCmd.AddCommand(setCmd())
+	stateCmd.AddCommand(showStateCmd())
+	stateCmd.AddCommand(setStateCmd())
 
 	rootCmd.AddCommand(stateCmd)
 }
@@ -26,7 +26,7 @@ var stateCmd = &cobra.Command{
 	Short: "Commands to configure the horcrux signer's state",
 }
 
-func showCmd() *cobra.Command {
+func showStateCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:     "show",
 		Aliases: []string{"s"},
@@ -65,7 +65,7 @@ func showCmd() *cobra.Command {
 	}
 }
 
-func setCmd() *cobra.Command {
+func setStateCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:     "set [height]",
 		Aliases: []string{"s"},

--- a/cmd/horcrux/cmd/state_test.go
+++ b/cmd/horcrux/cmd/state_test.go
@@ -22,6 +22,7 @@ func TestStateSetCmd(t *testing.T) {
 	require.NoError(t, err)
 
 	cmd := initCmd()
+	cmd.SetOutput(ioutil.Discard)
 	cmd.SetArgs([]string{
 		chainid,
 		"tcp://10.168.0.1:1234",

--- a/cmd/horcrux/cmd/state_test.go
+++ b/cmd/horcrux/cmd/state_test.go
@@ -50,7 +50,7 @@ func TestStateSetCmd(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd := setCmd()
+			cmd := setStateCmd()
 			cmd.SetArgs(tc.args)
 			err = cmd.Execute()
 			if tc.expectErr {

--- a/cmd/horcrux/cmd/state_test.go
+++ b/cmd/horcrux/cmd/state_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"io/ioutil"
 	"os"
 	"path"
 	"strconv"
@@ -51,8 +52,10 @@ func TestStateSetCmd(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			cmd := setStateCmd()
+			cmd.SetOutput(ioutil.Discard)
 			cmd.SetArgs(tc.args)
 			err = cmd.Execute()
+
 			if tc.expectErr {
 				require.Error(t, err)
 			} else {

--- a/cmd/horcrux/cmd/state_test.go
+++ b/cmd/horcrux/cmd/state_test.go
@@ -1,0 +1,89 @@
+package cmd
+
+import (
+	"os"
+	"path"
+	"strconv"
+	"testing"
+
+	"github.com/strangelove-ventures/horcrux/signer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStateSetCmd(t *testing.T) {
+	tmpHome := "/tmp/TestStateSetCmd"
+	tmpConfig := path.Join(tmpHome, ".horcrux")
+	chainid := "horcrux-1"
+
+	err := os.Setenv("HOME", tmpHome)
+	require.NoError(t, err)
+	err = os.MkdirAll(tmpHome, 0777)
+	require.NoError(t, err)
+
+	cmd := initCmd()
+	cmd.SetArgs([]string{
+		chainid,
+		"tcp://10.168.0.1:1234",
+		"-c",
+		"-p", "tcp://10.168.1.2:2222|2,tcp://10.168.1.3:2222|3",
+		"--timeout", "1500ms",
+	})
+	err = cmd.Execute()
+	require.NoError(t, err)
+
+	tcs := []struct {
+		name      string
+		args      []string
+		expectErr bool
+	}{
+		{
+			name:      "valid height",
+			args:      []string{"123456789"},
+			expectErr: false,
+		},
+		{
+			name:      "invalid height",
+			args:      []string{"-123456789"},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := setCmd()
+			cmd.SetArgs(tc.args)
+			err = cmd.Execute()
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+
+				height, err := strconv.ParseInt(tc.args[0], 10, 64)
+				require.NoError(t, err)
+
+				ss, err := signer.LoadSignState(path.Join(tmpConfig, "state", chainid+"_priv_validator_state.json"))
+				require.NoError(t, err)
+				require.Equal(t, height, ss.Height)
+				require.Equal(t, int64(0), ss.Round)
+				require.Equal(t, int8(0), ss.Step)
+				require.Nil(t, ss.EphemeralPublic)
+				require.Nil(t, ss.Signature)
+				require.Nil(t, ss.SignBytes)
+
+				ss, err = signer.LoadSignState(path.Join(tmpConfig, "state", chainid+"_share_sign_state.json"))
+				require.NoError(t, err)
+				require.Equal(t, height, ss.Height)
+				require.Equal(t, int64(0), ss.Round)
+				require.Equal(t, int8(0), ss.Step)
+				require.Nil(t, ss.EphemeralPublic)
+				require.Nil(t, ss.Signature)
+				require.Nil(t, ss.SignBytes)
+			}
+		})
+	}
+
+	t.Cleanup(func() {
+		err := os.RemoveAll(tmpHome)
+		require.NoError(t, err)
+	})
+}

--- a/cmd/horcrux/cmd/state_test.go
+++ b/cmd/horcrux/cmd/state_test.go
@@ -83,7 +83,6 @@ func TestStateSetCmd(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
-		err := os.RemoveAll(tmpHome)
-		require.NoError(t, err)
+		os.RemoveAll(tmpHome)
 	})
 }

--- a/cmd/horcrux/cmd/version.go
+++ b/cmd/horcrux/cmd/version.go
@@ -60,7 +60,7 @@ func NewInfo() Info {
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "version information for horcrux",
+	Short: "Version information for horcrux",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		bz, err := json.MarshalIndent(NewInfo(), "", "  ")
 		if err != nil {


### PR DESCRIPTION
This PR addresses #18.

- [X] `config nodes add/remove`
- [X] `config peers add/remove`
- [X] `config chain-id set`
- [X] `state pv show/reset (--height)`
- [X] `state share show/reset (--height)`
- [X] Tests

### Notes

I figured resetting either `pv` or `share` should only be possible if horcrux is not running since they are constantly being written to, so I put a unix-style cli check in there (for lack of a better go-style solution), which comes with a couple of caveats:

1. The check only works on UNIX-based systems.
2. The binary cannot be renamed to anything other than `horcrux`.