### PR TITLE
Allow releasing with version suffix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     branches: 
       - "RC[0-9]/**"
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+" # Push events to matching v*, i.e. v1.0, v20.15.10
+      - "v[0-9]+.[0-9]+.[0-9]+.*" # Push events to matching v*, i.e. v1.0, v20.15.10
 
 jobs:
   goreleaser:


### PR DESCRIPTION
Allow releasing tags with suffix after `v{major}.{minor}.{patch}`, e.g. `v2.0.0-beta1`