### PR TITLE
Fix race condition when initial leader is brought back up

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,20 +17,18 @@ jobs:
         with:
           go-version: 1.17
 
-      
       # checkout horcrux
       - name: checkout horcrux
         uses: actions/checkout@v2
 
-      # build cache
-      - uses: actions/cache@v1
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+      # cleanup docker environment on self-hosted test runner
+      - name: prepare fresh docker environment
+        run: |
+          docker stop $(docker ps -a -q) || true
+          docker rm -f $(docker ps -a -q) || true
+          docker network prune -f || true
 
-      # todo: pull image from repo
+      # todo: use heighliner image
       - name: build simd image
         run: make build-simd-docker
 

--- a/signer/cosigner_rpc_server.go
+++ b/signer/cosigner_rpc_server.go
@@ -114,5 +114,4 @@ func (rpcServer *CosignerRPCServer) rpcSetEphemeralSecretPartsAndSignRequest(
 func (rpcServer *CosignerRPCServer) rpcGetEphemeralSecretPartsRequest(
 	ctx *rpc_types.Context, req HRSKey) (*CosignerEphemeralSecretPartsResponse, error) {
 	return rpcServer.cosigner.GetEphemeralSecretParts(req)
-
 }

--- a/signer/raft_events.go
+++ b/signer/raft_events.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net"
-	"strings"
 )
 
 const (
@@ -37,16 +35,12 @@ func (f *fsm) handleLSSEvent(value string) {
 func (s *RaftStore) GetLeaderCosigner() (Cosigner, error) {
 	leader := string(s.GetLeader())
 	for _, peer := range s.Peers {
-		peerSplit := strings.Split(peer.GetRaftAddress(), ":")
-		ips, err := net.LookupIP(peerSplit[0])
-		if err == nil {
-			for _, ip := range ips {
-				peerAddress := fmt.Sprintf("%s:%s", ip, peerSplit[1])
-				if peerAddress == leader {
-					return peer, nil
-				}
-			}
-		} else if peer.GetAddress() == leader {
+		tcpAddress, err := GetTCPAddressForRaftAddress(peer.GetRaftAddress())
+		if err != nil {
+			s.logger.Error("Unable to get TCP address for peer", err)
+			continue
+		}
+		if fmt.Sprint(tcpAddress) == leader {
 			return peer, nil
 		}
 	}

--- a/signer/raft_store.go
+++ b/signer/raft_store.go
@@ -74,10 +74,6 @@ func (s *RaftStore) SetThresholdValidator(thresholdValidator *ThresholdValidator
 	s.thresholdValidator = thresholdValidator
 }
 
-func (s *RaftStore) isInitialLeader() bool {
-	return s.NodeID == "1"
-}
-
 // OnStart starts the raft server
 func (s *RaftStore) OnStart() error {
 	go func() {
@@ -85,18 +81,17 @@ func (s *RaftStore) OnStart() error {
 			s.logger.Error("failed to open raft store", err.Error())
 			return
 		}
-		if s.isInitialLeader() {
-			// Wait until bootstrap node is the leader.
-			// Timeout after 10 seconds, which would indicate that
-			// the cluster has a new leader, and this node is rejoining
-			for i := 0; i < 10 && s.raft.State() != raft.Leader; i++ {
-				time.Sleep(1 * time.Second)
-			}
-			s.joinCosigners()
-		}
 	}()
 
 	return nil
+}
+
+func GetTCPAddressForRaftAddress(raftAddress string) (*net.TCPAddr, error) {
+	addr, err := net.ResolveTCPAddr("tcp", raftAddress)
+	if err != nil {
+		return nil, err
+	}
+	return addr, nil
 }
 
 // Open opens the store. If enableSingle is set, and there are no existing peers,
@@ -108,12 +103,15 @@ func (s *RaftStore) Open() error {
 	config.LocalID = raft.ServerID(s.NodeID)
 	config.LogLevel = "ERROR"
 
-	// Setup Raft communication.
-	addr, err := net.ResolveTCPAddr("tcp", s.RaftBind)
+	tcpAddress, err := GetTCPAddressForRaftAddress(s.RaftBind)
 	if err != nil {
 		return err
 	}
-	transport, err := raft.NewTCPTransport(s.RaftBind, addr, 3, 10*time.Second, os.Stderr)
+	// Setup Raft communication.
+	transport, err := raft.NewTCPTransport(s.RaftBind, tcpAddress, 3, 10*time.Second, os.Stderr)
+	if err != nil {
+		return err
+	}
 	if err != nil {
 		return err
 	}
@@ -137,37 +135,28 @@ func (s *RaftStore) Open() error {
 	}
 	s.raft = ra
 
-	if s.isInitialLeader() {
-		configuration := raft.Configuration{
-			Servers: []raft.Server{
-				{
-					ID:      config.LocalID,
-					Address: transport.LocalAddr(),
-				},
+	configuration := raft.Configuration{
+		Servers: []raft.Server{
+			{
+				ID:      raft.ServerID(s.NodeID),
+				Address: transport.LocalAddr(),
 			},
-		}
-		ra.BootstrapCluster(configuration)
-	}
-
-	return nil
-}
-
-func (s *RaftStore) joinCosigners() {
-	// If we are not leader, do not want to attempt to join any cosigners.
-	// They are either already followers of the new leader, or will join the new leader
-	// when they come back up if they are currently down.
-	if s.raft.State() != raft.Leader {
-		return
+		},
 	}
 	for _, peer := range s.Peers {
-		nodeID := fmt.Sprint(peer.GetID())
-		raftAddress := peer.GetRaftAddress()
-		s.logger.Info("Adding node to cluster", nodeID, raftAddress)
-		err := s.Join(nodeID, raftAddress)
+		tcpAddress, err := GetTCPAddressForRaftAddress(peer.GetRaftAddress())
 		if err != nil {
-			s.logger.Error("Error joining cosigner to Raft cluster", nodeID, err.Error())
+			s.logger.Error("Error getting TCP address for peer", err)
+			continue
 		}
+		configuration.Servers = append(configuration.Servers, raft.Server{
+			ID:      raft.ServerID(fmt.Sprint(peer.GetID())),
+			Address: raft.ServerAddress(fmt.Sprint(tcpAddress)),
+		})
 	}
+	s.raft.BootstrapCluster(configuration)
+
+	return nil
 }
 
 // Get returns the value for the given key.

--- a/signer/raft_store.go
+++ b/signer/raft_store.go
@@ -139,19 +139,14 @@ func (s *RaftStore) Open() error {
 		Servers: []raft.Server{
 			{
 				ID:      raft.ServerID(s.NodeID),
-				Address: transport.LocalAddr(),
+				Address: raft.ServerAddress(s.RaftBind),
 			},
 		},
 	}
 	for _, peer := range s.Peers {
-		tcpAddress, err := GetTCPAddressForRaftAddress(peer.GetRaftAddress())
-		if err != nil {
-			s.logger.Error("Error getting TCP address for peer", err)
-			continue
-		}
 		configuration.Servers = append(configuration.Servers, raft.Server{
 			ID:      raft.ServerID(fmt.Sprint(peer.GetID())),
-			Address: raft.ServerAddress(fmt.Sprint(tcpAddress)),
+			Address: raft.ServerAddress(peer.GetRaftAddress()),
 		})
 	}
 	s.raft.BootstrapCluster(configuration)

--- a/test/horcrux_test.go
+++ b/test/horcrux_test.go
@@ -492,7 +492,7 @@ func TestDownedSigners2of3(t *testing.T) {
 
 		t.Logf("{%s} -> Checking that no blocks were missed...", ourValidator.Name())
 
-		time.Sleep(20 * time.Second) // let raft cluster recover from downed node
+		time.Sleep(30 * time.Second) // let raft cluster recover from downed node
 
 		ourValidator.EnsureNoMissedBlocks()
 
@@ -580,7 +580,7 @@ func TestDownedSigners3of5(t *testing.T) {
 			require.NoError(t, signer2.StopContainer())
 		}
 
-		time.Sleep(20 * time.Second) // let raft cluster recover from downed node
+		time.Sleep(30 * time.Second) // let raft cluster recover from downed node
 
 		t.Logf("{%s} -> Checking that no blocks were missed...", ourValidator.Name())
 		ourValidator.EnsureNoMissedBlocks() // allow up to 5 missed blocks

--- a/test/horcrux_test.go
+++ b/test/horcrux_test.go
@@ -588,7 +588,7 @@ func TestDownedSigners3of5(t *testing.T) {
 		ourValidator.WaitUntilStopMissingBlocks()
 
 		t.Logf("{%s} -> Checking that no blocks were missed...", ourValidator.Name())
-		ourValidator.EnsureNoMissedBlocks() // allow up to 5 missed blocks
+		ourValidator.EnsureNoMissedBlocks()
 
 		t.Logf("{%s} -> Restarting signer...", signer1.Name())
 		require.NoError(t, signer1.CreateCosignerContainer(network.ID))


### PR DESCRIPTION
Simplify cluster bring-up
No initial leader needs to be defined. The raft BootstrapCluster method can be called by non leaders, and errors can be ignored. By passing all peers to the initial raft configuration, no join calls are necessary. 
The signer that first starts will then be the initial leader, and it won't have issues when rejoining the cluster

Updates downed signer tests to wait for 3 consecutive successfully signed blocks after taking down a node before starting to check missed blocks from then on to make test assertions more concrete and functional on machines with different resources.