### PR TITLE
Indirect cosigner

### DIFF
--- a/signer/Cosigner.go
+++ b/signer/Cosigner.go
@@ -75,8 +75,4 @@ type Cosigner interface {
 
 	// Sign the requested bytes
 	SetEphemeralSecretPartsAndSign(req CosignerSetEphemeralSecretPartsAndSignRequest) (*CosignerSignResponse, error)
-
-	// Request that the cosigner manage the threshold signing process for this block
-	// Will throw error if cosigner is not the leader
-	SignBlock(req CosignerSignBlockRequest) (CosignerSignBlockResponse, error)
 }

--- a/signer/local_cosigner.go
+++ b/signer/local_cosigner.go
@@ -474,10 +474,6 @@ func (cosigner *LocalCosigner) setEphemeralSecretPart(req CosignerSetEphemeralSe
 	return nil
 }
 
-func (cosigner *LocalCosigner) SignBlock(req CosignerSignBlockRequest) (CosignerSignBlockResponse, error) {
-	return CosignerSignBlockResponse{}, errors.New("not implemented")
-}
-
 func (cosigner *LocalCosigner) SetEphemeralSecretPartsAndSign(
 	req CosignerSetEphemeralSecretPartsAndSignRequest) (*CosignerSignResponse, error) {
 	for _, secretPart := range req.EncryptedSecrets {

--- a/signer/raft_events.go
+++ b/signer/raft_events.go
@@ -2,7 +2,9 @@ package signer
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"strings"
 )
 
 const (
@@ -31,28 +33,39 @@ func (f *fsm) handleLSSEvent(value string) {
 	_ = f.cosigner.SaveLastSignedState(*lss)
 }
 
-func (s *RaftStore) GetLeaderCosigner() (Cosigner, error) {
+func (s *RaftStore) getLeaderRPCAddress() (string, error) {
 	leader := string(s.GetLeader())
+	if leader == "" {
+		return "", errors.New("no current raft leader")
+	}
+	// If the same RPC port is used for all peers, we can just use the leader address on that port
+	if s.commonRPCPort != "" {
+		leaderSplit := strings.Split(leader, ":")
+		if len(leaderSplit) == 2 {
+			return fmt.Sprintf("tcp://%s:%s", leaderSplit[0], s.commonRPCPort), nil
+		}
+	}
 	for _, peer := range s.Peers {
 		if peer.GetRaftAddress() == leader {
-			return peer, nil
+			return peer.GetAddress(), nil
 		}
 		tcpAddress, err := GetTCPAddressForRaftAddress(peer.GetRaftAddress())
 		if err != nil {
 			continue
 		}
 		if fmt.Sprint(tcpAddress) == leader {
-			return peer, nil
+			return peer.GetAddress(), nil
 		}
 	}
-	return nil, fmt.Errorf("unable to find leader cosigner from address %s", leader)
+
+	return "", fmt.Errorf("unable to find leader cosigner from address %s", leader)
 }
 
-func (s *RaftStore) LeaderSignBlock(req CosignerSignBlockRequest) (*CosignerSignBlockResponse, error) {
-	leaderCosigner, err := s.GetLeaderCosigner()
+func (s *RaftStore) LeaderSignBlock(req CosignerSignBlockRequest) (res *CosignerSignBlockResponse, err error) {
+	leaderCosigner, err := s.getLeaderRPCAddress()
 	if err != nil {
 		return nil, err
 	}
-	res, err := leaderCosigner.SignBlock(req)
-	return &res, err
+
+	return res, CallRPC(leaderCosigner, "SignBlock", req, &res)
 }

--- a/signer/remote_cosigner.go
+++ b/signer/remote_cosigner.go
@@ -42,11 +42,6 @@ func (cosigner *RemoteCosigner) GetEphemeralSecretParts(
 }
 
 // Implements the cosigner interface
-func (cosigner *RemoteCosigner) SignBlock(req CosignerSignBlockRequest) (res CosignerSignBlockResponse, err error) {
-	return res, CallRPC(cosigner.address, "SignBlock", req, &res)
-}
-
-// Implements the cosigner interface
 func (cosigner *RemoteCosigner) SetEphemeralSecretPartsAndSign(
 	req CosignerSetEphemeralSecretPartsAndSignRequest) (res *CosignerSignResponse, err error) {
 	return res, CallRPC(cosigner.address, "SetEphemeralSecretPartsAndSign", req, &res)


### PR DESCRIPTION
If the cosigners have any network hops, where the `raft-bind` address on one peer is not the same as the `raft-addr` cosigner raft address on the other peers, then the leader lookup from the raft address will fail.

### Context:
When we initialize the raft store in horcrux, we give the list of raft peers. For each peer, we give the horcrux cosigner ID for `raft.ServerID` (string) and the horcrux cosigner raft address for `raft.ServerAddress` (string).

Then during runtime, when we want to query the current leader, raft's `Leader()` method only returns the current leader's raft bind address `ServerAddress`, not the `ServerID`. The IP in the returned `ServerAddress` can be different from the configuration provided during initialization.

Since Raft does not have a way currently to get the leader's `ServerID`, which would easily allow us to determine which cosigner is the raft leader, there isn't a clean way to match the raft leader IP to a horcrux cosigner.

We have a fork to add this, see [our commit to add this](https://github.com/strangelove-ventures/raft/commit/1a765f172cdd3545f5dfd19039abbd01d21f8bdb) and the implementation of this functionality in horcrux in #52). We don't want to maintain a raft fork, so we can work on getting this functionality through hashicorp review and added to the upstream. For now, we can work around this issue as explained below.

### Example

An example of this type of configuration is within kubernetes, where the `raft-addr` config cosigner addresses point to the kubernetes service DNS hostnames (e.g. `signer-1`). Raft cannot bind to the kubernetes service IP, it needs to bind to the pod IP. But the pods have a different dynamic IP every time they come up, so these should not be used in the cosigners configuration. The signer pods can reach each other by their pod IP, so it's safe to use this IP on pod bring-up as the bind/advertise raft address `raft-bind`, but the kubernetes service hostname should be used for the cosigner configuration since this is a sure way to be able to route to the signer pods, even if pods are restarted.

### Workaround

When we query the leader using raft's `Leader()` method, if we see that all peers use the same RPC port (e.g. `2222`) we can take the returned `ServerAddress` (string) replace the raft port (e.g. `2223`) with the common RPC port (e.g. `2222`), and make the RPC call to the resulting address.

The caveat is that these kinds of network configurations will require using the same RPC port for all cosigners until we have a newer raft version that gives us the ability to get the `ServerID` of the raft leader.