### PR TITLE
Rename testing.T instances from test to t

### DIFF
--- a/signer/Serialization_test.go
+++ b/signer/Serialization_test.go
@@ -8,7 +8,7 @@ import (
 	tm "github.com/tendermint/tendermint/types"
 )
 
-func TestUnpackHRSPrevote(test *testing.T) {
+func TestUnpackHRSPrevote(t *testing.T) {
 	vote := tmproto.Vote{
 		Height: 1,
 		Round:  2,
@@ -18,13 +18,13 @@ func TestUnpackHRSPrevote(test *testing.T) {
 	signBytes := tm.VoteSignBytes("chain-id", &vote)
 
 	hrs, err := UnpackHRS(signBytes)
-	require.NoError(test, err)
-	require.Equal(test, int64(1), hrs.Height)
-	require.Equal(test, int64(2), hrs.Round)
-	require.Equal(test, int8(2), hrs.Step)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), hrs.Height)
+	require.Equal(t, int64(2), hrs.Round)
+	require.Equal(t, int8(2), hrs.Step)
 }
 
-func TestUnpackHRSPrecommit(test *testing.T) {
+func TestUnpackHRSPrecommit(t *testing.T) {
 	vote := tmproto.Vote{
 		Height: 3,
 		Round:  2,
@@ -34,13 +34,13 @@ func TestUnpackHRSPrecommit(test *testing.T) {
 	signBytes := tm.VoteSignBytes("chain-id", &vote)
 
 	hrs, err := UnpackHRS(signBytes)
-	require.NoError(test, err)
-	require.Equal(test, int64(3), hrs.Height)
-	require.Equal(test, int64(2), hrs.Round)
-	require.Equal(test, int8(3), hrs.Step)
+	require.NoError(t, err)
+	require.Equal(t, int64(3), hrs.Height)
+	require.Equal(t, int64(2), hrs.Round)
+	require.Equal(t, int8(3), hrs.Step)
 }
 
-func TestUnpackHRSProposal(test *testing.T) {
+func TestUnpackHRSProposal(t *testing.T) {
 	proposal := tmproto.Proposal{
 		Height: 1,
 		Round:  2,
@@ -50,8 +50,8 @@ func TestUnpackHRSProposal(test *testing.T) {
 	signBytes := tm.ProposalSignBytes("chain-id", &proposal)
 
 	hrs, err := UnpackHRS(signBytes)
-	require.NoError(test, err)
-	require.Equal(test, int64(1), hrs.Height)
-	require.Equal(test, int64(2), hrs.Round)
-	require.Equal(test, int8(1), hrs.Step)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), hrs.Height)
+	require.Equal(t, int64(2), hrs.Round)
+	require.Equal(t, int8(1), hrs.Step)
 }

--- a/signer/cosigner_key_test.go
+++ b/signer/cosigner_key_test.go
@@ -6,11 +6,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestLoadCosignerKey(test *testing.T) {
+func TestLoadCosignerKey(t *testing.T) {
 	key, err := LoadCosignerKey("./fixtures/cosigner-key.json")
-	require.NoError(test, err)
-	require.Equal(test, key.ID, 3)
+	require.NoError(t, err)
+	require.Equal(t, key.ID, 3)
 
 	// public key from cosigner pubs array should match public key from our private key
-	require.Equal(test, &key.RSAKey.PublicKey, key.CosignerKeys[key.ID-1])
+	require.Equal(t, &key.RSAKey.PublicKey, key.CosignerKeys[key.ID-1])
 }

--- a/signer/local_cosigner_test.go
+++ b/signer/local_cosigner_test.go
@@ -15,12 +15,12 @@ import (
 	tsed25519 "gitlab.com/polychainlabs/threshold-ed25519/pkg"
 )
 
-func TestLocalCosignerGetID(test *testing.T) {
+func TestLocalCosignerGetID(t *testing.T) {
 	dummyPub := tmCryptoEd25519.PubKey{}
 
 	bitSize := 4096
 	rsaKey, err := rsa.GenerateKey(rand.Reader, bitSize)
-	require.NoError(test, err)
+	require.NoError(t, err)
 
 	key := CosignerKey{
 		PubKey:   dummyPub,
@@ -44,10 +44,10 @@ func TestLocalCosignerGetID(test *testing.T) {
 	}
 
 	cosigner := NewLocalCosigner(config)
-	require.Equal(test, cosigner.GetID(), 1)
+	require.Equal(t, cosigner.GetID(), 1)
 }
 
-func TestLocalCosignerSign2of2(test *testing.T) {
+func TestLocalCosignerSign2of2(t *testing.T) {
 	// Test signing with a 2 of 2
 
 	total := uint8(2)
@@ -55,10 +55,10 @@ func TestLocalCosignerSign2of2(test *testing.T) {
 
 	bitSize := 4096
 	rsaKey1, err := rsa.GenerateKey(rand.Reader, bitSize)
-	require.NoError(test, err)
+	require.NoError(t, err)
 
 	rsaKey2, err := rsa.GenerateKey(rand.Reader, bitSize)
-	require.NoError(test, err)
+	require.NoError(t, err)
 
 	peers := []CosignerPeer{{
 		ID:        1,
@@ -81,11 +81,11 @@ func TestLocalCosignerSign2of2(test *testing.T) {
 	}
 
 	stateFile1, err := ioutil.TempFile("", "state1.json")
-	require.NoError(test, err)
+	require.NoError(t, err)
 	defer os.Remove(stateFile1.Name())
 
 	signState1, err := LoadOrCreateSignState(stateFile1.Name())
-	require.NoError(test, err)
+	require.NoError(t, err)
 
 	key2 := CosignerKey{
 		PubKey:   privateKey.PubKey(),
@@ -94,10 +94,10 @@ func TestLocalCosignerSign2of2(test *testing.T) {
 	}
 
 	stateFile2, err := ioutil.TempFile("", "state2.json")
-	require.NoError(test, err)
+	require.NoError(t, err)
 	defer os.Remove(stateFile2.Name())
 	signState2, err := LoadOrCreateSignState(stateFile2.Name())
-	require.NoError(test, err)
+	require.NoError(t, err)
 
 	config1 := LocalCosignerConfig{
 		CosignerKey: key1,
@@ -123,8 +123,8 @@ func TestLocalCosignerSign2of2(test *testing.T) {
 	cosigner1 = NewLocalCosigner(config1)
 	cosigner2 = NewLocalCosigner(config2)
 
-	require.Equal(test, cosigner1.GetID(), 1)
-	require.Equal(test, cosigner2.GetID(), 2)
+	require.Equal(t, cosigner1.GetID(), 1)
+	require.Equal(t, cosigner2.GetID(), 2)
 
 	publicKeys := make([]tsed25519.Element, 0)
 
@@ -135,12 +135,12 @@ func TestLocalCosignerSign2of2(test *testing.T) {
 	}
 
 	ephemeralSharesFor2, err := cosigner1.GetEphemeralSecretParts(hrs)
-	require.NoError(test, err)
+	require.NoError(t, err)
 
 	publicKeys = append(publicKeys, ephemeralSharesFor2.EncryptedSecrets[0].SourceEphemeralSecretPublicKey)
 
 	ephemeralSharesFor1, err := cosigner2.GetEphemeralSecretParts(hrs)
-	require.NoError(test, err)
+	require.NoError(t, err)
 
 	fmt.Printf("Shares from 2: %d\n", len(ephemeralSharesFor1.EncryptedSecrets))
 
@@ -163,14 +163,14 @@ func TestLocalCosignerSign2of2(test *testing.T) {
 		HRS:              hrs,
 		SignBytes:        signBytes,
 	})
-	require.NoError(test, err)
+	require.NoError(t, err)
 
 	sigRes2, err := cosigner2.SetEphemeralSecretPartsAndSign(CosignerSetEphemeralSecretPartsAndSignRequest{
 		EncryptedSecrets: ephemeralSharesFor2.EncryptedSecrets,
 		HRS:              hrs,
 		SignBytes:        signBytes,
 	})
-	require.NoError(test, err)
+	require.NoError(t, err)
 
 	sigIds := []int{1, 2}
 	sigArr := [][]byte{sigRes1.Signature, sigRes2.Signature}
@@ -182,10 +182,10 @@ func TestLocalCosignerSign2of2(test *testing.T) {
 	signature = append(signature, combinedSig...)
 
 	fmt.Printf("signature: %x\n", signature)
-	require.True(test, privateKey.PubKey().VerifySignature(signBytes, signature))
+	require.True(t, privateKey.PubKey().VerifySignature(signBytes, signature))
 }
 
-func TestLocalCosignerWatermark(test *testing.T) {
+func TestLocalCosignerWatermark(t *testing.T) {
 	/*
 		privateKey := tm_ed25519.GenPrivKey()
 
@@ -200,7 +200,7 @@ func TestLocalCosignerWatermark(test *testing.T) {
 		}
 
 		stateFile1, err := ioutil.TempFile("", "state1.json")
-		require.NoError(test, err)
+		require.NoError(t, err)
 		defer os.Remove(stateFile1.Name())
 
 		signState1, err := LoadOrCreateSignState(stateFile1.Name())
@@ -208,7 +208,7 @@ func TestLocalCosignerWatermark(test *testing.T) {
 		cosigner1 := NewLocalCosigner(key1, &signState1)
 
 		ephPublicKey, ephPrivateKey, err := ed25519.GenerateKey(rand.Reader)
-		require.NoError(test, err)
+		require.NoError(t, err)
 
 		ephShares := tsed25519.DealShares(ephPrivateKey.Seed(), 2, 2)
 
@@ -222,14 +222,14 @@ func TestLocalCosignerWatermark(test *testing.T) {
 		}
 
 		_, err = cosigner1.Sign(signReq1)
-		require.NoError(test, err)
+		require.NoError(t, err)
 
 		// watermark should have increased after signing
-		require.Equal(test, signState1.Height, int64(2))
+		require.Equal(t, signState1.Height, int64(2))
 
 		// revert the height to a lower number and check if signing is rejected
 		signReq1.Height = 1
 		_, err = cosigner1.Sign(signReq1)
-		require.Error(test, err, "height regression. Got 1, last height 2")
+		require.Error(t, err, "height regression. Got 1, last height 2")
 	*/
 }

--- a/signer/threshold_validator_test.go
+++ b/signer/threshold_validator_test.go
@@ -30,17 +30,16 @@ func getMockRaftStore(cosigner Cosigner, tmpDir string) *RaftStore {
 	}
 }
 
-func TestThresholdValidator2of2(test *testing.T) {
-
+func TestThresholdValidator2of2(t *testing.T) {
 	total := uint8(2)
 	threshold := uint8(2)
 
 	bitSize := 4096
 	rsaKey1, err := rsa.GenerateKey(rand.Reader, bitSize)
-	require.NoError(test, err)
+	require.NoError(t, err)
 
 	rsaKey2, err := rsa.GenerateKey(rand.Reader, bitSize)
-	require.NoError(test, err)
+	require.NoError(t, err)
 
 	peers := []CosignerPeer{{
 		ID:        1,
@@ -63,11 +62,11 @@ func TestThresholdValidator2of2(test *testing.T) {
 	}
 
 	stateFile1, err := ioutil.TempFile("", "state1.json")
-	require.NoError(test, err)
+	require.NoError(t, err)
 	defer os.Remove(stateFile1.Name())
 
 	signState1, err := LoadOrCreateSignState(stateFile1.Name())
-	require.NoError(test, err)
+	require.NoError(t, err)
 
 	key2 := CosignerKey{
 		PubKey:   privateKey.PubKey(),
@@ -76,10 +75,10 @@ func TestThresholdValidator2of2(test *testing.T) {
 	}
 
 	stateFile2, err := ioutil.TempFile("", "state2.json")
-	require.NoError(test, err)
+	require.NoError(t, err)
 	defer os.Remove(stateFile2.Name())
 	signState2, err := LoadOrCreateSignState(stateFile2.Name())
-	require.NoError(test, err)
+	require.NoError(t, err)
 
 	config1 := LocalCosignerConfig{
 		CosignerKey: key1,
@@ -105,8 +104,8 @@ func TestThresholdValidator2of2(test *testing.T) {
 	cosigner1 = NewLocalCosigner(config1)
 	cosigner2 = NewLocalCosigner(config2)
 
-	require.Equal(test, cosigner1.GetID(), 1)
-	require.Equal(test, cosigner2.GetID(), 2)
+	require.Equal(t, cosigner1.GetID(), 1)
+	require.Equal(t, cosigner2.GetID(), 2)
 
 	thresholdPeers := make([]Cosigner, 0)
 	thresholdPeers = append(thresholdPeers, cosigner2)
@@ -131,7 +130,7 @@ func TestThresholdValidator2of2(test *testing.T) {
 	raftStore.SetThresholdValidator(validator)
 
 	err = raftStore.Open()
-	require.NoError(test, err)
+	require.NoError(t, err)
 
 	time.Sleep(3 * time.Second) // Ensure there is a leader
 
@@ -143,25 +142,24 @@ func TestThresholdValidator2of2(test *testing.T) {
 	signBytes := tm.ProposalSignBytes("chain-id", &proposal)
 
 	err = validator.SignProposal("chain-id", &proposal)
-	require.NoError(test, err)
+	require.NoError(t, err)
 
-	require.True(test, privateKey.PubKey().VerifySignature(signBytes, proposal.Signature))
-
+	require.True(t, privateKey.PubKey().VerifySignature(signBytes, proposal.Signature))
 }
 
-func TestThresholdValidator3of3(test *testing.T) {
+func TestThresholdValidator3of3(t *testing.T) {
 	total := uint8(3)
 	threshold := uint8(3)
 
 	bitSize := 4096
 	rsaKey1, err := rsa.GenerateKey(rand.Reader, bitSize)
-	require.NoError(test, err)
+	require.NoError(t, err)
 
 	rsaKey2, err := rsa.GenerateKey(rand.Reader, bitSize)
-	require.NoError(test, err)
+	require.NoError(t, err)
 
 	rsaKey3, err := rsa.GenerateKey(rand.Reader, bitSize)
-	require.NoError(test, err)
+	require.NoError(t, err)
 
 	peers := []CosignerPeer{{
 		ID:        1,
@@ -187,11 +185,11 @@ func TestThresholdValidator3of3(test *testing.T) {
 	}
 
 	stateFile1, err := ioutil.TempFile("", "state1.json")
-	require.NoError(test, err)
+	require.NoError(t, err)
 	defer os.Remove(stateFile1.Name())
 
 	signState1, err := LoadOrCreateSignState(stateFile1.Name())
-	require.NoError(test, err)
+	require.NoError(t, err)
 
 	key2 := CosignerKey{
 		PubKey:   privateKey.PubKey(),
@@ -200,11 +198,11 @@ func TestThresholdValidator3of3(test *testing.T) {
 	}
 
 	stateFile2, err := ioutil.TempFile("", "state2.json")
-	require.NoError(test, err)
+	require.NoError(t, err)
 	defer os.Remove(stateFile2.Name())
 
 	signState2, err := LoadOrCreateSignState(stateFile2.Name())
-	require.NoError(test, err)
+	require.NoError(t, err)
 
 	key3 := CosignerKey{
 		PubKey:   privateKey.PubKey(),
@@ -213,11 +211,11 @@ func TestThresholdValidator3of3(test *testing.T) {
 	}
 
 	stateFile3, err := ioutil.TempFile("", "state3.json")
-	require.NoError(test, err)
+	require.NoError(t, err)
 	defer os.Remove(stateFile3.Name())
 
 	signState3, err := LoadOrCreateSignState(stateFile3.Name())
-	require.NoError(test, err)
+	require.NoError(t, err)
 
 	config1 := LocalCosignerConfig{
 		CosignerKey: key1,
@@ -254,9 +252,9 @@ func TestThresholdValidator3of3(test *testing.T) {
 	cosigner2 = NewLocalCosigner(config2)
 	cosigner3 = NewLocalCosigner(config3)
 
-	require.Equal(test, cosigner1.GetID(), 1)
-	require.Equal(test, cosigner2.GetID(), 2)
-	require.Equal(test, cosigner3.GetID(), 3)
+	require.Equal(t, cosigner1.GetID(), 1)
+	require.Equal(t, cosigner2.GetID(), 2)
+	require.Equal(t, cosigner3.GetID(), 3)
 
 	thresholdPeers := make([]Cosigner, 0)
 	thresholdPeers = append(thresholdPeers, cosigner2, cosigner3)
@@ -281,7 +279,7 @@ func TestThresholdValidator3of3(test *testing.T) {
 	raftStore.SetThresholdValidator(validator)
 
 	err = raftStore.Open()
-	require.NoError(test, err)
+	require.NoError(t, err)
 
 	time.Sleep(3 * time.Second) // Ensure there is a leader
 
@@ -294,27 +292,26 @@ func TestThresholdValidator3of3(test *testing.T) {
 
 	err = validator.SignProposal("chain-id", &proposal)
 	if err != nil {
-		test.Logf("%v", err)
+		t.Logf("%v", err)
 	}
-	require.NoError(test, err)
+	require.NoError(t, err)
 
-	require.True(test, privateKey.PubKey().VerifySignature(signBytes, proposal.Signature))
-
+	require.True(t, privateKey.PubKey().VerifySignature(signBytes, proposal.Signature))
 }
 
-func TestThresholdValidator2of3(test *testing.T) {
+func TestThresholdValidator2of3(t *testing.T) {
 	total := uint8(3)
 	threshold := uint8(2)
 
 	bitSize := 4096
 	rsaKey1, err := rsa.GenerateKey(rand.Reader, bitSize)
-	require.NoError(test, err)
+	require.NoError(t, err)
 
 	rsaKey2, err := rsa.GenerateKey(rand.Reader, bitSize)
-	require.NoError(test, err)
+	require.NoError(t, err)
 
 	rsaKey3, err := rsa.GenerateKey(rand.Reader, bitSize)
-	require.NoError(test, err)
+	require.NoError(t, err)
 
 	peers := []CosignerPeer{{
 		ID:        1,
@@ -340,11 +337,11 @@ func TestThresholdValidator2of3(test *testing.T) {
 	}
 
 	stateFile1, err := ioutil.TempFile("", "state1.json")
-	require.NoError(test, err)
+	require.NoError(t, err)
 	defer os.Remove(stateFile1.Name())
 
 	signState1, err := LoadOrCreateSignState(stateFile1.Name())
-	require.NoError(test, err)
+	require.NoError(t, err)
 
 	key2 := CosignerKey{
 		PubKey:   privateKey.PubKey(),
@@ -353,11 +350,11 @@ func TestThresholdValidator2of3(test *testing.T) {
 	}
 
 	stateFile2, err := ioutil.TempFile("", "state2.json")
-	require.NoError(test, err)
+	require.NoError(t, err)
 	defer os.Remove(stateFile2.Name())
 
 	signState2, err := LoadOrCreateSignState(stateFile2.Name())
-	require.NoError(test, err)
+	require.NoError(t, err)
 
 	key3 := CosignerKey{
 		PubKey:   privateKey.PubKey(),
@@ -366,11 +363,11 @@ func TestThresholdValidator2of3(test *testing.T) {
 	}
 
 	stateFile3, err := ioutil.TempFile("", "state3.json")
-	require.NoError(test, err)
+	require.NoError(t, err)
 	defer os.Remove(stateFile3.Name())
 
 	signState3, err := LoadOrCreateSignState(stateFile3.Name())
-	require.NoError(test, err)
+	require.NoError(t, err)
 
 	config1 := LocalCosignerConfig{
 		CosignerKey: key1,
@@ -407,9 +404,9 @@ func TestThresholdValidator2of3(test *testing.T) {
 	cosigner2 = NewLocalCosigner(config2)
 	cosigner3 = NewLocalCosigner(config3)
 
-	require.Equal(test, cosigner1.GetID(), 1)
-	require.Equal(test, cosigner2.GetID(), 2)
-	require.Equal(test, cosigner3.GetID(), 3)
+	require.Equal(t, cosigner1.GetID(), 1)
+	require.Equal(t, cosigner2.GetID(), 2)
+	require.Equal(t, cosigner3.GetID(), 3)
 
 	thresholdPeers := make([]Cosigner, 0)
 	thresholdPeers = append(thresholdPeers, cosigner2, cosigner3)
@@ -434,7 +431,7 @@ func TestThresholdValidator2of3(test *testing.T) {
 	raftStore.SetThresholdValidator(validator)
 
 	err = raftStore.Open()
-	require.NoError(test, err)
+	require.NoError(t, err)
 
 	time.Sleep(3 * time.Second) // Ensure there is a leader
 
@@ -447,10 +444,9 @@ func TestThresholdValidator2of3(test *testing.T) {
 
 	err = validator.SignProposal("chain-id", &proposal)
 	if err != nil {
-		test.Logf("%v", err)
+		t.Logf("%v", err)
 	}
-	require.NoError(test, err)
+	require.NoError(t, err)
 
-	require.True(test, privateKey.PubKey().VerifySignature(signBytes, proposal.Signature))
-
+	require.True(t, privateKey.PubKey().VerifySignature(signBytes, proposal.Signature))
 }


### PR DESCRIPTION
Idiomatic go always names the parameter t.