### PR TITLE
Sign votes with nil BlockID

### DIFF
--- a/signer/threshold_validator.go
+++ b/signer/threshold_validator.go
@@ -11,7 +11,6 @@ import (
 	proto "github.com/strangelove-ventures/horcrux/signer/proto"
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/libs/log"
-	"github.com/tendermint/tendermint/libs/protoio"
 	tmProto "github.com/tendermint/tendermint/proto/tendermint/types"
 	rpcTypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 	tm "github.com/tendermint/tendermint/types"
@@ -290,16 +289,6 @@ func (pv *ThresholdValidator) getExistingBlockSignature(block *Block) ([]byte, t
 
 func (pv *ThresholdValidator) SignBlock(chainID string, block *Block) ([]byte, time.Time, error) {
 	height, round, step, stamp, signBytes := block.Height, block.Round, block.Step, block.Timestamp, block.SignBytes
-
-	if step == stepPrevote || step == stepPrecommit {
-		var vote tmProto.CanonicalVote
-		if err := protoio.UnmarshalDelimited(signBytes, &vote); err != nil {
-			return nil, stamp, fmt.Errorf("signBytes cannot be unmarshalled into vote: %v", err)
-		}
-		if vote.BlockID == nil {
-			return nil, stamp, fmt.Errorf("refusing to sign nil BlockID")
-		}
-	}
 
 	// Only the leader can execute this function. Followers can handle the requests,
 	// but they just need to proxy the request to the raft leader


### PR DESCRIPTION
Since this is not a horcrux bug, reverting this change.
- increases uptime on chains using older/forked sdk/tm versions where all sentries will send sign vote requests for blocks with nil BlockID
- We do not see the issue of all sentries requesting votes to be signed with nil BlockID on chains using sdk version >= v0.44.0