### PR TITLE
Listen on defined address only

### DIFF
--- a/signer/raft_store.go
+++ b/signer/raft_store.go
@@ -86,11 +86,7 @@ func (s *RaftStore) SetThresholdValidator(thresholdValidator *ThresholdValidator
 
 func (s *RaftStore) init() error {
 	host := p2pURLToRaftAddress(s.RaftBind)
-	_, port, err := net.SplitHostPort(host)
-	if err != nil {
-		return fmt.Errorf("failed to parse local address: %s, %v", host, err)
-	}
-	sock, err := net.Listen("tcp", fmt.Sprintf(":%s", port))
+	sock, err := net.Listen("tcp", host)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description
The horcrux server is listening on all network interfaces. With this patch the `p2p-listen` address is taken into account as well.

With `p2p-listen: tcp://10.10.1.1:2222`
` lsof -i -P -n | grep LISTEN`
shows now
`horcrux    7u  IPv6  21097      0t0  TCP *:2222 (LISTEN)`
but it should be
`horcrux    6u  IPv4  21893      0t0  TCP 10.10.1.1:2222 (LISTEN)`

## Checklist

- [ ] I have made sure the upstream branch for this PR is correct
- [ ] I have made sure this PR is ready to merge
- [ ] I have made sure that I have assigned reviewers related to this project

## Changes

- [ ] Added ...
- [ ] Changed ...
- [ ] Removed ...

## Screenshots

...

## Testing

- Open page ...
- Click ...
- Make sure that ...

## Links/References

- ...
- ...
- ...

## Notes

- ...
- ...
- ...
