### PR TITLE
Fix isRunning check

### DIFF
--- a/cmd/horcrux/cmd/state.go
+++ b/cmd/horcrux/cmd/state.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path"
 	"strconv"
+	"strings"
 
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
@@ -122,9 +123,14 @@ func setStateCmd() *cobra.Command {
 }
 
 func isRunning() bool {
-	pipe := "ps -ax | pgrep horcrux"
+	pipe := "ps -ax | grep horcrux | wc -l"
 	bz, _ := exec.Command("bash", "-c", pipe).Output()
-	return len(bz) != 0
+	numRunning, err := strconv.ParseUint(strings.TrimSpace(string(bz)), 10, 64)
+	if err != nil {
+		panic(err)
+	}
+	// one is the bash command, one is the grep command, one is this horcrux command. If any more, then horcrux is running as a daemon.
+	return numRunning > 3
 }
 
 func printSignState(ss signer.SignState) {


### PR DESCRIPTION
`isRunning` was returning true if the byte output length of `ps ax | pgrep horcrux` was 0, which will always be true because there is a newline in the stdout.

Now it will return true if the number returned by `ps -ax | grep horcrux | wc -l` is greater than 3, which accounts for the 3 running process PIDS that will mention `horcrux`:
- Running horcrux command e.g. `horcrux set state 123`
- `bash -c 'ps -ax | grep horcrux | wc -l'`
- `grep horcrux | wc -l`

Any more than 3 would indicate that another process named horcrux is running, such as the daemon.

Closes #79 