### PR TITLE
Optional args in usage

### DIFF
--- a/cmd/horcrux/cmd/cosigner.go
+++ b/cmd/horcrux/cmd/cosigner.go
@@ -38,8 +38,9 @@ type AddressCmdOutput struct {
 
 func AddressCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "address",
+		Use:          "address [bech32]",
 		Short:        "Get public key hex address and valcons address",
+		Example:      `horcrux cosigner address cosmos`,
 		SilenceUsage: true,
 		Args:         cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {

--- a/cmd/horcrux/cmd/leader_election.go
+++ b/cmd/horcrux/cmd/leader_election.go
@@ -23,12 +23,14 @@ func init() {
 }
 
 var leaderElectionCmd = &cobra.Command{
-	Use:   "elect",
+	Use:   "elect [node_id]",
 	Short: "Elect new raft leader",
 	Long: `To choose the next eligible leader, pass no argument.
 To choose a specific leader, pass that leader's ID as an argument.
 `,
-	Args:         cobra.RangeArgs(0, 1),
+	Args: cobra.RangeArgs(0, 1),
+	Example: `horcrux elect # elect random leader
+horcrux elect 2 # elect specific leader`,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		if config.Config.CosignerConfig == nil {

--- a/cmd/horcrux/cmd/leader_election.go
+++ b/cmd/horcrux/cmd/leader_election.go
@@ -29,7 +29,7 @@ var leaderElectionCmd = &cobra.Command{
 To choose a specific leader, pass that leader's ID as an argument.
 `,
 	Args: cobra.RangeArgs(0, 1),
-	Example: `horcrux elect # elect random leader
+	Example: `horcrux elect # elect next eligible leader
 horcrux elect 2 # elect specific leader`,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) (err error) {


### PR DESCRIPTION
Adds optional args to `Use` and `Example` for `cosigner address` and `elect` commands:

`$ horcrux cosigner address -h`
```
Get public key hex address and valcons address

Usage:
  horcrux cosigner address [bech32] [flags]

Examples:
horcrux cosigner address cosmos

Flags:
  -h, --help   help for address

Global Flags:
      --home string   Directory for config and data (default is $HOME/.horcrux)
```

`$ horcrux elect -h`
```
To choose the next eligible leader, pass no argument.
To choose a specific leader, pass that leader's ID as an argument.

Usage:
  horcrux elect [node_id] [flags]

Examples:
horcrux elect # elect random leader
horcrux elect 2 # elect specific leader

Flags:
  -h, --help   help for elect

Global Flags:
      --home string   Directory for config and data (default is $HOME/.horcrux)
```

Closes #81 