### PR TITLE
update dep url for threshold-ed25519 and edwards25519

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,8 +20,8 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/tendermint/go-amino v0.16.0
 	github.com/tendermint/tendermint v0.34.14
-	gitlab.com/polychainlabs/edwards25519 v0.0.0-20200206000358-2272e01758fb
-	gitlab.com/polychainlabs/threshold-ed25519 v0.0.0-20200221030822-1c35a36a51c1
+	gitlab.com/unit410/edwards25519 v0.0.0-20220725154547-61980033348e
+	gitlab.com/unit410/threshold-ed25519 v0.0.0-20220725172740-6ee731f539ac
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	google.golang.org/grpc v1.44.0
 	google.golang.org/protobuf v1.27.1

--- a/go.sum
+++ b/go.sum
@@ -876,10 +876,10 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/zondax/hid v0.9.0 h1:eiT3P6vNxAEVxXMw66eZUAAnU2zD33JBkfG/EnfAKl8=
 github.com/zondax/hid v0.9.0/go.mod h1:l5wttcP0jwtdLjqjMMWFVEE7d1zO0jvSPA9OPZxWpEM=
-gitlab.com/polychainlabs/edwards25519 v0.0.0-20200206000358-2272e01758fb h1:AdKE1d1TA0YYg8FDChkZP/nFOQDOMOUxLYzac/eVYUU=
-gitlab.com/polychainlabs/edwards25519 v0.0.0-20200206000358-2272e01758fb/go.mod h1:3KUw8eOHmnX0bANpqw52h/JNsGJxfVIFyhIXH5zeprc=
-gitlab.com/polychainlabs/threshold-ed25519 v0.0.0-20200221030822-1c35a36a51c1 h1:zdHgoRHlPqZfRMew5hX7aPZuxNURbcobivw+4gMvipk=
-gitlab.com/polychainlabs/threshold-ed25519 v0.0.0-20200221030822-1c35a36a51c1/go.mod h1:jrwPQCmLa5H51H4qgUAZcigi2rz2kFLVEkGe3eNlzHw=
+gitlab.com/unit410/edwards25519 v0.0.0-20220725154547-61980033348e h1:/QfokHt2yG9PcjnFSdpIQhJwrz2Q1bmKA718vw4/He8=
+gitlab.com/unit410/edwards25519 v0.0.0-20220725154547-61980033348e/go.mod h1:lTSPILLBMt6qQOJgsiarbW85JhpkhoOfW2EBkxkcuSI=
+gitlab.com/unit410/threshold-ed25519 v0.0.0-20220725172740-6ee731f539ac h1:SUxQNWwBUVFdvRP72Wi1wZ8K2iD7+SXFfMUMJyMCJjc=
+gitlab.com/unit410/threshold-ed25519 v0.0.0-20220725172740-6ee731f539ac/go.mod h1:2TURxKmaBFbTDxXQa+B2nGuKSRWD0Jlcc3LETTAnSS0=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.5 h1:XAzx9gjCb0Rxj7EoqcClPD1d5ZBxZJk0jbuoPHenBt0=

--- a/signer/cosigner_key_shares.go
+++ b/signer/cosigner_key_shares.go
@@ -8,7 +8,7 @@ import (
 
 	tmjson "github.com/tendermint/tendermint/libs/json"
 	"github.com/tendermint/tendermint/privval"
-	tsed25519 "gitlab.com/polychainlabs/threshold-ed25519/pkg"
+	tsed25519 "gitlab.com/unit410/threshold-ed25519/pkg"
 )
 
 // CreateCosignerSharesFromFile creates cosigner key objects from a priv_validator_key.json file
@@ -57,7 +57,7 @@ func WriteCosignerShareFile(cosigner CosignerKey, file string) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(file, jsonBytes, 0644) //nolint
+	return ioutil.WriteFile(file, jsonBytes, 0644) // nolint
 }
 
 func makeRSAKeys(num int) (rsaKeys []*rsa.PrivateKey, pubKeys []*rsa.PublicKey, err error) {

--- a/signer/local_cosigner.go
+++ b/signer/local_cosigner.go
@@ -13,8 +13,8 @@ import (
 
 	tmCryptoEd25519 "github.com/tendermint/tendermint/crypto/ed25519"
 	tmJson "github.com/tendermint/tendermint/libs/json"
-	"gitlab.com/polychainlabs/edwards25519"
-	tsed25519 "gitlab.com/polychainlabs/threshold-ed25519/pkg"
+	"gitlab.com/unit410/edwards25519"
+	tsed25519 "gitlab.com/unit410/threshold-ed25519/pkg"
 )
 
 // return true if we are less than the other key

--- a/signer/local_cosigner_test.go
+++ b/signer/local_cosigner_test.go
@@ -12,7 +12,7 @@ import (
 	tmCryptoEd25519 "github.com/tendermint/tendermint/crypto/ed25519"
 	tmProto "github.com/tendermint/tendermint/proto/tendermint/types"
 	tm "github.com/tendermint/tendermint/types"
-	tsed25519 "gitlab.com/polychainlabs/threshold-ed25519/pkg"
+	tsed25519 "gitlab.com/unit410/threshold-ed25519/pkg"
 )
 
 func TestLocalCosignerGetID(t *testing.T) {

--- a/signer/threshold_validator.go
+++ b/signer/threshold_validator.go
@@ -14,7 +14,7 @@ import (
 	tmProto "github.com/tendermint/tendermint/proto/tendermint/types"
 	rpcTypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 	tm "github.com/tendermint/tendermint/types"
-	tsed25519 "gitlab.com/polychainlabs/threshold-ed25519/pkg"
+	tsed25519 "gitlab.com/unit410/threshold-ed25519/pkg"
 )
 
 type ThresholdValidator struct {

--- a/signer/threshold_validator_test.go
+++ b/signer/threshold_validator_test.go
@@ -14,7 +14,7 @@ import (
 	tmlog "github.com/tendermint/tendermint/libs/log"
 	tmProto "github.com/tendermint/tendermint/proto/tendermint/types"
 	tm "github.com/tendermint/tendermint/types"
-	tsed25519 "gitlab.com/polychainlabs/threshold-ed25519/pkg"
+	tsed25519 "gitlab.com/unit410/threshold-ed25519/pkg"
 )
 
 func getMockRaftStore(cosigner Cosigner, tmpDir string) *RaftStore {


### PR DESCRIPTION
<!-- markdownlint-disable MD014 MD033 MD034 MD036 MD041 -->

## Description

The go module names for `threshold-ed25519` and `edwards25519` were updated (upstream) changing `polychainlabs` to `unit410`. These changes update the names herein, and although not necessarily _required_, are aimed at avoiding any issues down the road.

## Checklist

- [ ] I have made sure the upstream branch for this PR is correct
- [ ] I have made sure this PR is ready to merge
- [ ] I have made sure that I have assigned reviewers related to this project

## Changes

- [ ] Added ...
- [ ] Changed ...
- [ ] Removed ...

## Screenshots

...

## Testing

- Open page ...
- Click ...
- Make sure that ...

## Links/References

- [threshold-ed25519](https://gitlab.com/unit410/threshold-ed25519/-/merge_requests/2)
- [edwards25519](https://gitlab.com/unit410/edwards25519/-/merge_requests/1)
- ...

## Notes

- ...
- ...
- ...
