### PR TITLE
Add prometheus signer and cosigner metrics

### DIFF
--- a/cmd/horcrux/cmd/config.go
+++ b/cmd/horcrux/cmd/config.go
@@ -74,7 +74,7 @@ func initCmd() *cobra.Command {
 			if keyFileFlag != "" {
 				keyFile = &keyFileFlag
 			}
-			debugListenAddress, _ := cmdFlags.GetString("debuglisten")
+			debugAddr, _ := cmdFlags.GetString("debug-addr")
 			if cs {
 				// Cosigner Config
 				p, _ := cmdFlags.GetString("peers")
@@ -111,8 +111,8 @@ func initCmd() *cobra.Command {
 						Peers:     peers,
 						Timeout:   timeout,
 					},
-					ChainNodes:         cn,
-					DebugListenAddress: debugListenAddress,
+					ChainNodes: cn,
+					DebugAddr:  debugAddr,
 				}
 				if err = validateCosignerConfig(cfg); err != nil {
 					return err
@@ -122,12 +122,11 @@ func initCmd() *cobra.Command {
 				if len(cn) == 0 {
 					return fmt.Errorf("must input at least one node")
 				}
-				debugListenAddress, _ := cmdFlags.GetString("debuglisten")
 				cfg = DiskConfig{
-					PrivValKeyFile:     keyFile,
-					ChainID:            cid,
-					ChainNodes:         cn,
-					DebugListenAddress: debugListenAddress,
+					PrivValKeyFile: keyFile,
+					ChainID:        cid,
+					ChainNodes:     cn,
+					DebugAddr:      debugAddr,
 				}
 				if err = validateSingleSignerConfig(cfg); err != nil {
 					return err
@@ -168,7 +167,7 @@ func initCmd() *cobra.Command {
 		"(i.e. \"tcp://node-1:2222|2,tcp://node-2:2222|3\")")
 	cmd.Flags().IntP("threshold", "t", 0, "indicate number of signatures required for threshold signature")
 	cmd.Flags().StringP("listen", "l", "", "listen address of the signer")
-	cmd.Flags().StringP("debuglisten", "d", "", "listen address for Debug and Prometheus metrics in format localhost:8543")
+	cmd.Flags().StringP("debug-addr", "d", "", "listen address for Debug and Prometheus metrics in format localhost:8543")
 	cmd.Flags().StringP("keyfile", "k", "",
 		"priv val key file path (full key for single signer, or key share for cosigner)")
 	cmd.Flags().String("timeout", "1500ms", "configure cosigner rpc server timeout value, \n"+
@@ -488,11 +487,11 @@ func setChainIDCmd() *cobra.Command {
 
 // Config maps to the on-disk JSON format
 type DiskConfig struct {
-	PrivValKeyFile     *string         `json:"key-file,omitempty" yaml:"key-file,omitempty"`
-	ChainID            string          `json:"chain-id" yaml:"chain-id"`
-	CosignerConfig     *CosignerConfig `json:"cosigner,omitempty" yaml:"cosigner,omitempty"`
-	ChainNodes         []ChainNode     `json:"chain-nodes,omitempty" yaml:"chain-nodes,omitempty"`
-	DebugListenAddress string          `json:"debug-listen-address,omitempty" yaml:"debug-listen-address,omitempty"` //nolint
+	PrivValKeyFile *string         `json:"key-file,omitempty" yaml:"key-file,omitempty"`
+	ChainID        string          `json:"chain-id" yaml:"chain-id"`
+	CosignerConfig *CosignerConfig `json:"cosigner,omitempty" yaml:"cosigner,omitempty"`
+	ChainNodes     []ChainNode     `json:"chain-nodes,omitempty" yaml:"chain-nodes,omitempty"`
+	DebugAddr      string          `json:"debug-addr,omitempty" yaml:"debug-addr,omitempty"` //nolint
 }
 
 func (c *DiskConfig) Nodes() []signer.NodeConfig {

--- a/cmd/horcrux/cmd/config.go
+++ b/cmd/horcrux/cmd/config.go
@@ -491,7 +491,7 @@ type DiskConfig struct {
 	ChainID        string          `json:"chain-id" yaml:"chain-id"`
 	CosignerConfig *CosignerConfig `json:"cosigner,omitempty" yaml:"cosigner,omitempty"`
 	ChainNodes     []ChainNode     `json:"chain-nodes,omitempty" yaml:"chain-nodes,omitempty"`
-	DebugAddr      string          `json:"debug-addr,omitempty" yaml:"debug-addr,omitempty"` //nolint
+	DebugAddr      string          `json:"debug-addr,omitempty" yaml:"debug-addr,omitempty"`
 }
 
 func (c *DiskConfig) Nodes() []signer.NodeConfig {

--- a/cmd/horcrux/cmd/config.go
+++ b/cmd/horcrux/cmd/config.go
@@ -122,12 +122,12 @@ func initCmd() *cobra.Command {
 				if len(cn) == 0 {
 					return fmt.Errorf("must input at least one node")
 				}
-				prometheusListenAddress, _ := cmdFlags.GetString("metrics")
+				debugListenAddress, _ := cmdFlags.GetString("debuglisten")
 				cfg = DiskConfig{
 					PrivValKeyFile:     keyFile,
 					ChainID:            cid,
 					ChainNodes:         cn,
-					DebugListenAddress: prometheusListenAddress,
+					DebugListenAddress: debugListenAddress,
 				}
 				if err = validateSingleSignerConfig(cfg); err != nil {
 					return err
@@ -168,7 +168,7 @@ func initCmd() *cobra.Command {
 		"(i.e. \"tcp://node-1:2222|2,tcp://node-2:2222|3\")")
 	cmd.Flags().IntP("threshold", "t", 0, "indicate number of signatures required for threshold signature")
 	cmd.Flags().StringP("listen", "l", "", "listen address of the signer")
-	cmd.Flags().StringP("debuglisten", "d", "", "listen address for Debug and Prometheus metrics")
+	cmd.Flags().StringP("debuglisten", "d", "", "listen address for Debug and Prometheus metrics in format localhost:8543")
 	cmd.Flags().StringP("keyfile", "k", "",
 		"priv val key file path (full key for single signer, or key share for cosigner)")
 	cmd.Flags().String("timeout", "1500ms", "configure cosigner rpc server timeout value, \n"+

--- a/cmd/horcrux/cmd/config.go
+++ b/cmd/horcrux/cmd/config.go
@@ -492,7 +492,7 @@ type DiskConfig struct {
 	ChainID                 string          `json:"chain-id" yaml:"chain-id"`
 	CosignerConfig          *CosignerConfig `json:"cosigner,omitempty" yaml:"cosigner,omitempty"`
 	ChainNodes              []ChainNode     `json:"chain-nodes,omitempty" yaml:"chain-nodes,omitempty"`
-	PrometheusListenAddress string          `json:"prometheus-listen-address,omitempty" yaml:"prometheus-listen-address,omitempty"`
+	PrometheusListenAddress string          `json:"prometheus-listen-address,omitempty" yaml:"prometheus-listen-address,omitempty"` //nolint
 }
 
 func (c *DiskConfig) Nodes() []signer.NodeConfig {

--- a/cmd/horcrux/cmd/config.go
+++ b/cmd/horcrux/cmd/config.go
@@ -74,7 +74,7 @@ func initCmd() *cobra.Command {
 			if keyFileFlag != "" {
 				keyFile = &keyFileFlag
 			}
-			prometheusListenAddress, _ := cmdFlags.GetString("metrics")
+			debugListenAddress, _ := cmdFlags.GetString("debuglisten")
 			if cs {
 				// Cosigner Config
 				p, _ := cmdFlags.GetString("peers")
@@ -111,8 +111,8 @@ func initCmd() *cobra.Command {
 						Peers:     peers,
 						Timeout:   timeout,
 					},
-					ChainNodes:              cn,
-					PrometheusListenAddress: prometheusListenAddress,
+					ChainNodes:         cn,
+					DebugListenAddress: debugListenAddress,
 				}
 				if err = validateCosignerConfig(cfg); err != nil {
 					return err
@@ -124,10 +124,10 @@ func initCmd() *cobra.Command {
 				}
 				prometheusListenAddress, _ := cmdFlags.GetString("metrics")
 				cfg = DiskConfig{
-					PrivValKeyFile:          keyFile,
-					ChainID:                 cid,
-					ChainNodes:              cn,
-					PrometheusListenAddress: prometheusListenAddress,
+					PrivValKeyFile:     keyFile,
+					ChainID:            cid,
+					ChainNodes:         cn,
+					DebugListenAddress: prometheusListenAddress,
 				}
 				if err = validateSingleSignerConfig(cfg); err != nil {
 					return err
@@ -168,7 +168,7 @@ func initCmd() *cobra.Command {
 		"(i.e. \"tcp://node-1:2222|2,tcp://node-2:2222|3\")")
 	cmd.Flags().IntP("threshold", "t", 0, "indicate number of signatures required for threshold signature")
 	cmd.Flags().StringP("listen", "l", "", "listen address of the signer")
-	cmd.Flags().StringP("metrics", "m", "", "listen address for prometheus metrics")
+	cmd.Flags().StringP("debuglisten", "d", "", "listen address for Debug and Prometheus metrics")
 	cmd.Flags().StringP("keyfile", "k", "",
 		"priv val key file path (full key for single signer, or key share for cosigner)")
 	cmd.Flags().String("timeout", "1500ms", "configure cosigner rpc server timeout value, \n"+
@@ -488,11 +488,11 @@ func setChainIDCmd() *cobra.Command {
 
 // Config maps to the on-disk JSON format
 type DiskConfig struct {
-	PrivValKeyFile          *string         `json:"key-file,omitempty" yaml:"key-file,omitempty"`
-	ChainID                 string          `json:"chain-id" yaml:"chain-id"`
-	CosignerConfig          *CosignerConfig `json:"cosigner,omitempty" yaml:"cosigner,omitempty"`
-	ChainNodes              []ChainNode     `json:"chain-nodes,omitempty" yaml:"chain-nodes,omitempty"`
-	PrometheusListenAddress string          `json:"prometheus-listen-address,omitempty" yaml:"prometheus-listen-address,omitempty"` //nolint
+	PrivValKeyFile     *string         `json:"key-file,omitempty" yaml:"key-file,omitempty"`
+	ChainID            string          `json:"chain-id" yaml:"chain-id"`
+	CosignerConfig     *CosignerConfig `json:"cosigner,omitempty" yaml:"cosigner,omitempty"`
+	ChainNodes         []ChainNode     `json:"chain-nodes,omitempty" yaml:"chain-nodes,omitempty"`
+	DebugListenAddress string          `json:"debug-listen-address,omitempty" yaml:"debug-listen-address,omitempty"` //nolint
 }
 
 func (c *DiskConfig) Nodes() []signer.NodeConfig {

--- a/cmd/horcrux/cmd/cosigner.go
+++ b/cmd/horcrux/cmd/cosigner.go
@@ -239,7 +239,7 @@ func StartCosignerCmd() *cobra.Command {
 			}
 			logger.Info("Signer", "address", pubkey.Address())
 
-			go EnableDebugAndMetrics()
+			go EnableDebugAndMetrics(cmd.Context())
 
 			services, err = signer.StartRemoteSigners(services, logger, cfg.ChainID, pv, cfg.Nodes)
 			if err != nil {

--- a/cmd/horcrux/cmd/cosigner.go
+++ b/cmd/horcrux/cmd/cosigner.go
@@ -239,7 +239,7 @@ func StartCosignerCmd() *cobra.Command {
 			}
 			logger.Info("Signer", "address", pubkey.Address())
 
-			go StartMetrics()
+			go EnableDebugAndMetrics()
 
 			services, err = signer.StartRemoteSigners(services, logger, cfg.ChainID, pv, cfg.Nodes)
 			if err != nil {

--- a/cmd/horcrux/cmd/cosigner.go
+++ b/cmd/horcrux/cmd/cosigner.go
@@ -239,6 +239,8 @@ func StartCosignerCmd() *cobra.Command {
 			}
 			logger.Info("Signer", "address", pubkey.Address())
 
+			go StartMetrics()
+
 			services, err = signer.StartRemoteSigners(services, logger, cfg.ChainID, pv, cfg.Nodes)
 			if err != nil {
 				panic(err)

--- a/cmd/horcrux/cmd/metrics.go
+++ b/cmd/horcrux/cmd/metrics.go
@@ -30,7 +30,7 @@ func AddPrometheusMetrics(mux *http.ServeMux) {
 	}
 
 	mux.Handle("/metrics", promhttp.Handler())
-	logger.Info("Prometheus Metrics Listening", "address", config.Config.DebugListenAddress, "path", "/metrics")
+	logger.Info("Prometheus Metrics Listening", "address", config.Config.DebugAddr, "path", "/metrics")
 }
 
 // EnableDebugAndMetrics - Initialization errors are not fatal, only logged
@@ -38,11 +38,11 @@ func EnableDebugAndMetrics() {
 	logger := tmlog.NewTMLogger(tmlog.NewSyncWriter(os.Stdout)).With("module", "debugserver")
 
 	// Configure Shared Debug HTTP Server for pprof and prometheus
-	if len(config.Config.DebugListenAddress) == 0 {
-		logger.Info("debug-listen-address not defined; debug server disabled")
+	if len(config.Config.DebugAddr) == 0 {
+		logger.Info("debug-addr not defined; debug server disabled")
 		return
 	}
-	logger.Info("Debug Server Listening", "address", config.Config.DebugListenAddress)
+	logger.Info("Debug Server Listening", "address", config.Config.DebugAddr)
 
 	// Set up new mux identical to the default mux configuration in net/http/pprof.
 	mux := http.NewServeMux()
@@ -64,7 +64,7 @@ func EnableDebugAndMetrics() {
 		Handler: mux,
 		//ErrorLog: &logger,
 
-		Addr:              config.Config.DebugListenAddress,
+		Addr:              config.Config.DebugAddr,
 		ReadTimeout:       1 * time.Second,
 		WriteTimeout:      30 * time.Second,
 		IdleTimeout:       30 * time.Second,

--- a/cmd/horcrux/cmd/metrics.go
+++ b/cmd/horcrux/cmd/metrics.go
@@ -76,7 +76,7 @@ func EnableDebugAndMetrics(ctx context.Context) {
 	go func() {
 		if err := srv.ListenAndServe(); err != nil {
 			if err.Error() == "http: Server closed" {
-				logger.Info(fmt.Sprintf("Debug Server Shutdown Complete"))
+				logger.Info("Debug Server Shutdown Complete")
 				return
 			}
 			logger.Error(fmt.Sprintf("Debug Endpoint failed to start: %+v", err))

--- a/cmd/horcrux/cmd/metrics.go
+++ b/cmd/horcrux/cmd/metrics.go
@@ -3,13 +3,22 @@ package cmd
 import (
 	"fmt"
 	"net/http"
+	"os"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	tmlog "github.com/tendermint/tendermint/libs/log"
 )
 
 func StartMetrics() {
+	logger := tmlog.NewTMLogger(tmlog.NewSyncWriter(os.Stdout)).With("module", "metrics")
+
+	if len(config.Config.PrometheusListenAddress) == 0 {
+		logger.Error("prometheus-listen-address not defined")
+		return
+	}
+	logger.Info("Prometheus Metrics Listening", "address", config.Config.PrometheusListenAddress)
 	http.Handle("/metrics", promhttp.Handler())
-	if err := http.ListenAndServe(":2112", nil); err != nil {
-		fmt.Printf("Prometheus Endpoint failed to start: %s\n", err)
+	if err := http.ListenAndServe(config.Config.PrometheusListenAddress, nil); err != nil {
+		logger.Error(fmt.Sprintf("Prometheus Endpoint failed to start: %s", err))
 	}
 }

--- a/cmd/horcrux/cmd/metrics.go
+++ b/cmd/horcrux/cmd/metrics.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	tmlog "github.com/tendermint/tendermint/libs/log"
@@ -18,7 +19,16 @@ func StartMetrics() {
 	}
 	logger.Info("Prometheus Metrics Listening", "address", config.Config.PrometheusListenAddress)
 	http.Handle("/metrics", promhttp.Handler())
-	if err := http.ListenAndServe(config.Config.PrometheusListenAddress, nil); err != nil {
+
+	srv := &http.Server{
+		Addr:              config.Config.PrometheusListenAddress,
+		ReadTimeout:       1 * time.Second,
+		WriteTimeout:      1 * time.Second,
+		IdleTimeout:       30 * time.Second,
+		ReadHeaderTimeout: 2 * time.Second,
+	}
+
+	if err := srv.ListenAndServe(); err != nil {
 		logger.Error(fmt.Sprintf("Prometheus Endpoint failed to start: %s", err))
 	}
 }

--- a/cmd/horcrux/cmd/metrics.go
+++ b/cmd/horcrux/cmd/metrics.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"net/http"
+	"net/http/pprof"
 	"os"
 	"time"
 
@@ -13,7 +14,7 @@ import (
 	tmlog "github.com/tendermint/tendermint/libs/log"
 )
 
-func StartMetrics() {
+func AddPrometheusMetrics(mux *http.ServeMux) {
 	logger := tmlog.NewTMLogger(tmlog.NewSyncWriter(os.Stdout)).With("module", "metrics")
 
 	// Add raft metrics to prometheus
@@ -32,24 +33,51 @@ func StartMetrics() {
 		}
 	}
 
-	// Configure Prometheus HTTP Server and Handler
+	mux.Handle("/metrics", promhttp.Handler())
+	logger.Info("Prometheus Metrics Listening", "address", config.Config.DebugListenAddress, "path", "/metrics")
+}
 
-	if len(config.Config.PrometheusListenAddress) == 0 {
-		logger.Error("prometheus-listen-address not defined")
+// EnableDebugAndMetrics - Initialization errors are not fatal, only logged
+func EnableDebugAndMetrics() {
+	logger := tmlog.NewTMLogger(tmlog.NewSyncWriter(os.Stdout)).With("module", "debugserver")
+
+	// Configure Shared Debug HTTP Server for pprof and prometheus
+	if len(config.Config.DebugListenAddress) == 0 {
+		logger.Error("debug-listen-address not defined")
 		return
 	}
-	logger.Info("Prometheus Metrics Listening", "address", config.Config.PrometheusListenAddress)
-	http.Handle("/metrics", promhttp.Handler())
+	logger.Info("Debug Server Listening", "address", config.Config.DebugListenAddress)
 
+	// Set up new mux identical to the default mux configuration in net/http/pprof.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+	// And redirect the browser to the /debug/pprof root,
+	// so operators don't see a mysterious 404 page.
+	mux.Handle("/", http.RedirectHandler("/debug/pprof", http.StatusSeeOther))
+
+	// Add prometheus metrics
+	AddPrometheusMetrics(mux)
+
+	// Configure Debug Server Network Parameters
 	srv := &http.Server{
-		Addr:              config.Config.PrometheusListenAddress,
+		Handler: mux,
+		//ErrorLog: &logger,
+
+		Addr:              config.Config.DebugListenAddress,
 		ReadTimeout:       1 * time.Second,
-		WriteTimeout:      1 * time.Second,
+		WriteTimeout:      30 * time.Second,
 		IdleTimeout:       30 * time.Second,
 		ReadHeaderTimeout: 2 * time.Second,
 	}
 
+	// Start Debug Server.
 	if err := srv.ListenAndServe(); err != nil {
-		logger.Error(fmt.Sprintf("Prometheus Endpoint failed to start: %s", err))
+		logger.Error(fmt.Sprintf("Debug Endpoint failed to start: %s", err))
+		return
 	}
 }

--- a/cmd/horcrux/cmd/metrics.go
+++ b/cmd/horcrux/cmd/metrics.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+func StartMetrics() {
+	http.Handle("/metrics", promhttp.Handler())
+	if err := http.ListenAndServe(":2112", nil); err != nil {
+		fmt.Printf("Prometheus Endpoint failed to start: %s\n", err)
+	}
+}

--- a/cmd/horcrux/cmd/metrics.go
+++ b/cmd/horcrux/cmd/metrics.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/pprof"
@@ -62,9 +63,7 @@ func EnableDebugAndMetrics(ctx context.Context) {
 
 	// Configure Debug Server Network Parameters
 	srv := &http.Server{
-		Handler: mux,
-		//ErrorLog: &logger,
-
+		Handler:           mux,
 		Addr:              config.Config.DebugAddr,
 		ReadTimeout:       1 * time.Second,
 		WriteTimeout:      30 * time.Second,
@@ -75,7 +74,7 @@ func EnableDebugAndMetrics(ctx context.Context) {
 	// Start Debug Server.
 	go func() {
 		if err := srv.ListenAndServe(); err != nil {
-			if err.Error() == "http: Server closed" {
+			if errors.Is(err, http.ErrServerClosed) {
 				logger.Info("Debug Server Shutdown Complete")
 				return
 			}

--- a/cmd/horcrux/cmd/signer.go
+++ b/cmd/horcrux/cmd/signer.go
@@ -72,7 +72,7 @@ func StartSignerCmd() *cobra.Command {
 			}
 			logger.Info("Signer", "pubkey", pubkey)
 
-			go EnableDebugAndMetrics()
+			go EnableDebugAndMetrics(cmd.Context())
 
 			services, err = signer.StartRemoteSigners(services, logger, cfg.ChainID, pv, cfg.Nodes)
 			if err != nil {

--- a/cmd/horcrux/cmd/signer.go
+++ b/cmd/horcrux/cmd/signer.go
@@ -72,7 +72,7 @@ func StartSignerCmd() *cobra.Command {
 			}
 			logger.Info("Signer", "pubkey", pubkey)
 
-			go StartMetrics()
+			go EnableDebugAndMetrics()
 
 			services, err = signer.StartRemoteSigners(services, logger, cfg.ChainID, pv, cfg.Nodes)
 			if err != nil {

--- a/cmd/horcrux/cmd/signer.go
+++ b/cmd/horcrux/cmd/signer.go
@@ -72,6 +72,8 @@ func StartSignerCmd() *cobra.Command {
 			}
 			logger.Info("Signer", "pubkey", pubkey)
 
+			go StartMetrics()
+
 			services, err = signer.StartRemoteSigners(services, logger, cfg.ChainID, pv, cfg.Nodes)
 			if err != nil {
 				panic(err)

--- a/cmd/horcrux/cmd/state.go
+++ b/cmd/horcrux/cmd/state.go
@@ -102,6 +102,7 @@ func setStateCmd() *cobra.Command {
 				return err
 			}
 
+			fmt.Printf("Setting height %d\n", height)
 			pv.EphemeralPublic, share.EphemeralPublic = nil, nil
 			signState := signer.SignStateConsensus{
 				Height:    height,

--- a/cmd/horcrux/cmd/state.go
+++ b/cmd/horcrux/cmd/state.go
@@ -102,7 +102,8 @@ func setStateCmd() *cobra.Command {
 				return err
 			}
 
-			fmt.Printf("Setting height %d\n", height)
+			fmt.Fprintf(cmd.OutOrStdout(), "Setting height %d\n", height)
+
 			pv.EphemeralPublic, share.EphemeralPublic = nil, nil
 			signState := signer.SignStateConsensus{
 				Height:    height,

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -29,6 +29,18 @@ chain-nodes:
 prometheus-listen-address: 0.0.0.0:6001
 ```
 
+## Prometheus Cautions
+
+Prometheus scrapes data every minute by default which is not fast enough to log metrics which change on a fast interval.
+
+Set the scrape_interval between 1 and 3 seconds in prometheus.yml if you wish to log/monitor these metrics. Note this will take more disk space.
+
+```
+global:
+  scrape_interval: 3s
+```
+
+
 ## Watching Single Signers
 
 Single node signers don't execute any cosigner code, so the basic metrics are:
@@ -47,8 +59,15 @@ If there are skips in the block heights requested to be signed the following cou
 
 Watch 'signer_total_sentry_connect_tries' which reports retry connects to the specified sentry.  Any increase is an indicator of network or sentry process failure
 
+## Watching Cosigner With Grafana
+
+A sample Grapfana configration is available.  See [`horcrux.json`](https://github.com/chillyvee/horcrux-info/blob/master/grafana/horcrux.json)
+
+
 ## Watching For Cosigner Trouble
 Metrics may vary between Cosigner processes since there is only one leader.
+
+Watch 'signer_missed_ephemeral_shares' which will note when the leader is not able to get a signature from the peer.  If 'signer_total_missed_ephemeral_shares' increases to a high number, this may indicate a larger issue.
 
 Each block, Ephemeral Secrets are shared between Cosigners.  Monitoring 'signer_seconds_since_last_local_ephemeral_share_time' and ensuring it does not exceed the block time will allow you to know when a Cosigner was not contacted for a block.
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -63,7 +63,7 @@ If 'signer_total_sentry_connect_tries' is significant, it can indicate network o
 
 ## Watching Cosigner With Grafana
 
-A sample Grapfana configration is available.  See [`horcrux.json`](https://github.com/chillyvee/horcrux-info/blob/master/grafana/horcrux.json)
+A sample Grafana configration is available.  See [`horcrux.json`](https://github.com/chillyvee/horcrux-info/blob/master/grafana/horcrux.json)
 
 
 ## Watching For Cosigner Trouble

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -8,7 +8,7 @@ horcrux ..options.. -m 0.0.0.0:8001
 
 For earlier adopters, add the following key to your config.toml
 
-prometheus-listen-address: 0.0.0.0:6001
+debug-listen-address: 0.0.0.0:6001
 
 Resulting in a configuration like the following:
 
@@ -26,7 +26,7 @@ cosigner:
   rpc-timeout: 1500ms
 chain-nodes:
 - priv-val-addr: tcp://localhost:2300
-prometheus-listen-address: 0.0.0.0:6001
+debug-listen-address: 0.0.0.0:6001
 ```
 
 ## Prometheus Cautions

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,103 @@
+# Prometheus Metrics
+
+## Enabling Prometheus 
+Specify the port for incoming prometheus connections during 'config init' by using the -m flag.
+```
+horcrux ..options.. -m 0.0.0.0:8001
+```
+
+For earlier adopters, add the following key to your config.toml
+
+prometheus-listen-address: 0.0.0.0:6001
+
+Resulting in a configuration like the following:
+
+```
+chain-id: testnet-1
+cosigner:
+  threshold: 2
+  shares: 3
+  p2p-listen: tcp://localhost:5001
+  peers:
+  - share-id: 2
+    p2p-addr: tcp://localhost:5002
+  - share-id: 3
+    p2p-addr: tcp://localhost:5003
+  rpc-timeout: 1500ms
+chain-nodes:
+- priv-val-addr: tcp://localhost:2300
+prometheus-listen-address: 0.0.0.0:6001
+```
+
+## Watching Single Signers
+
+Single node signers don't execute any cosigner code, so the basic metrics are:
+ * signer_seconds_since_last_precommit 
+ * signer_seconds_since_last_prevote
+ * signer_last_precommit_height
+ * signer_last_prevote_height 
+
+If the 'seconds_since' metrics exceeds the normal block time, it may indicate a sentry failure or a network stall/halt.
+
+If there are skips in the block heights requested to be signed the following counters will increase AFTER the sentry is able to report the latest block height.  Until then, from the perspective of horcrux, it looks no different than a network stall.
+ * signer_total_missed_precommits 
+ * signer_total_missed_prevotes 
+
+## Watching Sentry Failure
+
+Watch 'signer_total_sentry_connect_tries' which reports retry connects to the specified sentry.  Any increase is an indicator of network or sentry process failure
+
+## Watching For Cosigner Trouble
+Metrics may vary between Cosigner processes since there is only one leader.
+
+Each block, Ephemeral Secrets are shared between Cosigners.  Monitoring 'signer_seconds_since_last_local_ephemeral_share_time' and ensuring it does not exceed the block time will allow you to know when a Cosigner was not contacted for a block.
+
+## Metrics that don't always correspond to block time
+There is no guarantee that a Cosigner will sign a block if the threshold is reached early.  You may watch 'signer_seconds_since_last_local_sign_start_time' but there is no guarantee that 'signer_seconds_since_last_local_sign_finish_time' will be reached since there are multiple sanity checks that may cause an early exit in some circumstances (rather rare)
+
+## Metrics on the raft leader may be different
+On the leader you may watch but these metrics will continue to rise on Cosigners who are not the raft leaders (since followers will rarely manage the original signing request)
+ * signer_seconds_since_last_precommit
+ * signer_seconds_since_last_prevote
+
+As a result, followers also do not update these metrics
+* signer_last_precommit_height
+* signer_last_prevote_height 
+
+
+## Checking Signing Performance
+We currently only have metrics between the leader and followers (not full p2p metrics).  However it is still useful in determining when a particular peer lags significantly.
+
+Your cluster should reach the threshold for availability in a short time.  Monitor the following:
+
+```
+signer_sign_block_threshold_lag_seconds{quantile="0.5"} 0.019399953
+signer_sign_block_threshold_lag_seconds{quantile="0.9"} 0.028546635
+signer_sign_block_threshold_lag_seconds{quantile="0.99"} 0.029730841
+```
+
+After reaching the threshold, all cosigners should sign quickly
+```
+signer_sign_block_cosigner_lag_seconds{quantile="0.5"} 0.031424561
+signer_sign_block_cosigner_lag_seconds{quantile="0.9"} 0.0407505
+signer_sign_block_cosigner_lag_seconds{quantile="0.99"} 0.045173791
+```
+
+If 'signer_sign_block_cosigner_lag_seconds' takes a significant amount of time, you can check the performance of each cosigner as it is seen by the raft leader.  High numbers may indicate a high latency link or a resource.  This metric is only available on the Leader and will report 'NaN' on followers.
+```
+signer_cosigner_sign_lag_seconds{peerid="tcp://localhost:5001",quantile="0.5"} 0.010391636
+signer_cosigner_sign_lag_seconds{peerid="tcp://localhost:5001",quantile="0.9"} 0.013242445
+signer_cosigner_sign_lag_seconds{peerid="tcp://localhost:5001",quantile="0.99"} 0.017128885
+signer_cosigner_sign_lag_seconds_sum{peerid="tcp://localhost:5001"} 1.1935657130000004
+signer_cosigner_sign_lag_seconds_count{peerid="tcp://localhost:5001"} 120
+signer_cosigner_sign_lag_seconds{peerid="tcp://localhost:5002",quantile="0.5"} 0.010473575
+signer_cosigner_sign_lag_seconds{peerid="tcp://localhost:5002",quantile="0.9"} 0.013052952
+signer_cosigner_sign_lag_seconds{peerid="tcp://localhost:5002",quantile="0.99"} 0.01732663
+signer_cosigner_sign_lag_seconds_sum{peerid="tcp://localhost:5002"} 1.014658521
+signer_cosigner_sign_lag_seconds_count{peerid="tcp://localhost:5002"} 103
+signer_cosigner_sign_lag_seconds{peerid="tcp://localhost:5003",quantile="0.5"} 0.010760536
+signer_cosigner_sign_lag_seconds{peerid="tcp://localhost:5003",quantile="0.9"} 0.012623563
+signer_cosigner_sign_lag_seconds{peerid="tcp://localhost:5003",quantile="0.99"} 0.016456836
+```
+
+

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -57,7 +57,9 @@ If there are skips in the block heights requested to be signed the following cou
 
 ## Watching Sentry Failure
 
-Watch 'signer_total_sentry_connect_tries' which reports retry connects to the specified sentry.  Any increase is an indicator of network or sentry process failure
+Watch 'signer_sentry_connect_tries' for any increase which indicates retry attempts to reach your sentry.  
+
+If 'signer_total_sentry_connect_tries' is significant, it can indicate network or server issues.
 
 ## Watching Cosigner With Grafana
 

--- a/signer/local_cosigner.go
+++ b/signer/local_cosigner.go
@@ -156,7 +156,9 @@ func (cosigner *LocalCosigner) GetAddress() string {
 // Return the signed bytes or an error
 // Implements Cosigner interface
 func (cosigner *LocalCosigner) sign(req CosignerSignRequest) (CosignerSignResponse, error) {
+	metricsPeriodicUpdateMutex.Lock()
 	previousLocalSignStartTime = time.Now() // This function has multiple exit points.  Only start time can be guaranteed
+	metricsPeriodicUpdateMutex.Unlock()
 
 	cosigner.lastSignStateMutex.Lock()
 	defer cosigner.lastSignStateMutex.Unlock()
@@ -251,7 +253,10 @@ func (cosigner *LocalCosigner) sign(req CosignerSignRequest) (CosignerSignRespon
 	res.Signature = sig
 
 	// Note - Function may return before this line so elapsed time for Finish may be multiple block times
+	metricsPeriodicUpdateMutex.Lock()
 	previousLocalSignFinishTime = time.Now()
+	metricsPeriodicUpdateMutex.Unlock()
+
 	return res, nil
 }
 
@@ -291,7 +296,10 @@ func (cosigner *LocalCosigner) dealShares(req CosignerGetEphemeralSecretPartRequ
 
 func (cosigner *LocalCosigner) GetEphemeralSecretParts(
 	hrst HRSTKey) (*CosignerEphemeralSecretPartsResponse, error) {
+	metricsPeriodicUpdateMutex.Lock()
 	previousLocalEphemeralShareTime = time.Now()
+	metricsPeriodicUpdateMutex.Unlock()
+
 	res := &CosignerEphemeralSecretPartsResponse{
 		EncryptedSecrets: make([]CosignerEphemeralSecretPart, 0, len(cosigner.peers)-1),
 	}

--- a/signer/local_cosigner.go
+++ b/signer/local_cosigner.go
@@ -156,7 +156,8 @@ func (cosigner *LocalCosigner) GetAddress() string {
 // Return the signed bytes or an error
 // Implements Cosigner interface
 func (cosigner *LocalCosigner) sign(req CosignerSignRequest) (CosignerSignResponse, error) {
-	metricsTimeKeeper.SetPreviousLocalSignStart(time.Now()) // This function has multiple exit points.  Only start time can be guaranteed
+	// This function has multiple exit points.  Only start time can be guaranteed
+	metricsTimeKeeper.SetPreviousLocalSignStart(time.Now())
 
 	cosigner.lastSignStateMutex.Lock()
 	defer cosigner.lastSignStateMutex.Unlock()

--- a/signer/local_cosigner.go
+++ b/signer/local_cosigner.go
@@ -156,9 +156,7 @@ func (cosigner *LocalCosigner) GetAddress() string {
 // Return the signed bytes or an error
 // Implements Cosigner interface
 func (cosigner *LocalCosigner) sign(req CosignerSignRequest) (CosignerSignResponse, error) {
-	metricsPeriodicUpdateMutex.Lock()
-	previousLocalSignStartTime = time.Now() // This function has multiple exit points.  Only start time can be guaranteed
-	metricsPeriodicUpdateMutex.Unlock()
+	metricsTimeKeeper.SetPreviousLocalSignStart(time.Now()) // This function has multiple exit points.  Only start time can be guaranteed
 
 	cosigner.lastSignStateMutex.Lock()
 	defer cosigner.lastSignStateMutex.Unlock()
@@ -253,9 +251,7 @@ func (cosigner *LocalCosigner) sign(req CosignerSignRequest) (CosignerSignRespon
 	res.Signature = sig
 
 	// Note - Function may return before this line so elapsed time for Finish may be multiple block times
-	metricsPeriodicUpdateMutex.Lock()
-	previousLocalSignFinishTime = time.Now()
-	metricsPeriodicUpdateMutex.Unlock()
+	metricsTimeKeeper.SetPreviousLocalSignFinish(time.Now())
 
 	return res, nil
 }
@@ -296,9 +292,7 @@ func (cosigner *LocalCosigner) dealShares(req CosignerGetEphemeralSecretPartRequ
 
 func (cosigner *LocalCosigner) GetEphemeralSecretParts(
 	hrst HRSTKey) (*CosignerEphemeralSecretPartsResponse, error) {
-	metricsPeriodicUpdateMutex.Lock()
-	previousLocalEphemeralShareTime = time.Now()
-	metricsPeriodicUpdateMutex.Unlock()
+	metricsTimeKeeper.SetPreviousLocalEphemeralShare(time.Now())
 
 	res := &CosignerEphemeralSecretPartsResponse{
 		EncryptedSecrets: make([]CosignerEphemeralSecretPart, 0, len(cosigner.peers)-1),

--- a/signer/local_cosigner.go
+++ b/signer/local_cosigner.go
@@ -250,7 +250,8 @@ func (cosigner *LocalCosigner) sign(req CosignerSignRequest) (CosignerSignRespon
 	res.EphemeralPublic = ephemeralPublic
 	res.Signature = sig
 
-	previousLocalSignFinishTime = time.Now() // Note - Function may return before this line so elapsed time for Finish may be multiple block times
+	// Note - Function may return before this line so elapsed time for Finish may be multiple block times
+	previousLocalSignFinishTime = time.Now()
 	return res, nil
 }
 

--- a/signer/metrics.go
+++ b/signer/metrics.go
@@ -175,6 +175,14 @@ var (
 		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 	})
 
+	timedCosignerEphemeralShareLag = promauto.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Name:       "signer_cosigner_ephemeral_share_lag_seconds",
+			Help:       "Time taken to get cosigner ephemeral share",
+			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+		},
+		[]string{"peerid"},
+	)
 	timedCosignerSignLag = promauto.NewSummaryVec(
 		prometheus.SummaryOpts{
 			Name:       "signer_cosigner_sign_lag_seconds",

--- a/signer/metrics.go
+++ b/signer/metrics.go
@@ -1,0 +1,94 @@
+package signer
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	// Variables to calculate Prometheus Metrics
+	previousPrecommitHeight = int64(0)
+	previousPrevoteHeight   = int64(0)
+	previousPrecommitTime   = time.Now()
+	previousPrevoteTime     = time.Now()
+
+	// Prometheus Metrics
+	lastPrecommitHeight = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "signer_last_precommit_height",
+		Help: "Last Height Precommit Signed",
+	})
+	lastPrevoteHeight = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "signer_last_prevote_height",
+		Help: "Last Height Prevote Signed",
+	})
+	lastProposalHeight = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "signer_last_proposal_height",
+		Help: "Last Height Proposal Signed",
+	})
+	lastPrecommitRound = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "signer_last_precommit_round",
+		Help: "Last Round Precommit Signed",
+	})
+	lastPrevoteRound = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "signer_last_prevote_round",
+		Help: "Last Round Prevote Signed",
+	})
+	lastProposalRound = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "signer_last_proposal_round",
+		Help: "Last Round Proposal Signed",
+	})
+
+	totalPrecommitsSigned = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "signer_total_precommits_signed",
+		Help: "Total Precommit Signed",
+	})
+	totalPrevotesSigned = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "signer_total_prevotes_signed",
+		Help: "Total Prevote Signed",
+	})
+	totalProposalsSigned = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "signer_total_proposals_signed",
+		Help: "Total Proposal Signed",
+	})
+
+	secondsSinceLastPrecommit = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "signer_seconds_since_last_precommit",
+		Help: "Seconds Since Last Precommit",
+	})
+	secondsSinceLastPrevote = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "signer_seconds_since_last_prevote",
+		Help: "Seconds Since Last Prevote",
+	})
+
+	missedPrecommits = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "signer_missed_precommits",
+		Help: "Consecutive Precommit Missed",
+	})
+	missedPrevotes = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "signer_missed_prevotes",
+		Help: "Consecutive Prevote Missed",
+	})
+	totalMissedPrecommits = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "signer_total_missed_precommits",
+		Help: "Total Precommit Missed",
+	})
+	totalMissedPrevotes = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "signer_total_missed_prevotes",
+		Help: "Total Prevote Missed",
+	})
+
+	totalSentryConnectTries = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "signer_total_sentry_connect_tries",
+		Help: "Total Number of times sentry TCP connect has been tried",
+	})
+)
+
+func StartMetrics() {
+	for {
+		secondsSinceLastPrecommit.Set(time.Since(previousPrecommitTime).Seconds())
+		secondsSinceLastPrevote.Set(time.Since(previousPrevoteTime).Seconds())
+		<-time.After(250 * time.Millisecond)
+	}
+}

--- a/signer/metrics.go
+++ b/signer/metrics.go
@@ -116,6 +116,10 @@ var (
 		[]string{"peerid"},
 	)
 
+	sentryConnectTries = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "signer_sentry_connect_tries",
+		Help: "Consecutive Number of times sentry TCP connect has been tried (High count may indicate validator restarts)",
+	})
 	totalSentryConnectTries = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "signer_total_sentry_connect_tries",
 		Help: "Total Number of times sentry TCP connect has been tried (High count may indicate validator restarts)",

--- a/signer/metrics.go
+++ b/signer/metrics.go
@@ -101,6 +101,21 @@ var (
 		Help: "Total Prevote Missed",
 	})
 
+	missedEphemeralShares = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "signer_missed_ephemeral_shares",
+			Help: "Consecutive Threshold Signature Parts Missed",
+		},
+		[]string{"peerid"},
+	)
+	totalMissedEphemeralShares = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "signer_total_missed_ephemeral_shares",
+			Help: "Total Threshold Signature Parts Missed",
+		},
+		[]string{"peerid"},
+	)
+
 	totalSentryConnectTries = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "signer_total_sentry_connect_tries",
 		Help: "Total Number of times sentry TCP connect has been tried (High count may indicate validator restarts)",
@@ -122,6 +137,10 @@ var (
 	totalNotRaftLeader = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "signer_total_raft_not_leader",
 		Help: "Total Times Signer is NOT Raft Leader (Proxy signing to Raft Leader)",
+	})
+	totalRaftLeaderElectiontimeout = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "signer_total_raft_leader_election_timeout",
+		Help: "Total Times Raft Leader Failed Election (Lacking Peers)",
 	})
 
 	totalInvalidSignature = promauto.NewCounter(prometheus.CounterOpts{
@@ -164,11 +183,12 @@ var (
 
 func StartMetrics() {
 	for {
+		// Update elapsed times on an interval basis
 		secondsSinceLastPrecommit.Set(time.Since(previousPrecommitTime).Seconds())
 		secondsSinceLastPrevote.Set(time.Since(previousPrevoteTime).Seconds())
 		secondsSinceLastLocalSignStart.Set(time.Since(previousLocalSignStartTime).Seconds())
 		secondsSinceLastLocalSignFinish.Set(time.Since(previousLocalSignFinishTime).Seconds())
 		secondsSinceLastLocalEphemeralShareTime.Set(time.Since(previousLocalEphemeralShareTime).Seconds())
-		<-time.After(250 * time.Millisecond)
+		<-time.After(100 * time.Millisecond)
 	}
 }

--- a/signer/metrics.go
+++ b/signer/metrics.go
@@ -75,12 +75,13 @@ var (
 	})
 	secondsSinceLastLocalSignFinish = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "signer_seconds_since_last_local_sign_finish_time",
-		Help: "Seconds Since Last Local Finish Sign (May increase to about 2 * Block Time; If high, CoSigner is not signing) ",
+		Help: "Seconds Since Last Local Finish Sign (Should stay below 2 * Block Time)",
 	})
 
 	secondsSinceLastLocalEphemeralShareTime = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "signer_seconds_since_last_local_ephemeral_share_time",
-		Help: "Seconds Since Last Local Ephemeral Share Sign (Should not increase beyond block time; If high, may indicate raft joining issue for CoSigner) ",
+		Help: "Seconds Since Last Local Ephemeral Share Sign " +
+			"(Should not increase beyond block time; If high, may indicate raft joining issue for CoSigner) ",
 	})
 
 	missedPrecommits = promauto.NewGauge(prometheus.GaugeOpts{
@@ -114,10 +115,6 @@ var (
 		Help: "Total Times Signer Failed to sign block - Unstarted and Unexepcted Height",
 	})
 
-	flagRaftLeader = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "signer_is_raft_leader",
-		Help: "Signer is Raft Leader",
-	})
 	totalRaftLeader = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "signer_total_raft_leader",
 		Help: "Total Times Signer is Raft Leader",

--- a/signer/metrics.go
+++ b/signer/metrics.go
@@ -104,15 +104,15 @@ var (
 		Help: "Last Round Proposal Signed",
 	})
 
-	totalPrecommitsSigned = promauto.NewGauge(prometheus.GaugeOpts{
+	totalPrecommitsSigned = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "signer_total_precommits_signed",
 		Help: "Total Precommit Signed",
 	})
-	totalPrevotesSigned = promauto.NewGauge(prometheus.GaugeOpts{
+	totalPrevotesSigned = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "signer_total_prevotes_signed",
 		Help: "Total Prevote Signed",
 	})
-	totalProposalsSigned = promauto.NewGauge(prometheus.GaugeOpts{
+	totalProposalsSigned = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "signer_total_proposals_signed",
 		Help: "Total Proposal Signed",
 	})
@@ -148,11 +148,11 @@ var (
 		Name: "signer_missed_prevotes",
 		Help: "Consecutive Prevote Missed",
 	})
-	totalMissedPrecommits = promauto.NewGauge(prometheus.GaugeOpts{
+	totalMissedPrecommits = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "signer_total_missed_precommits",
 		Help: "Total Precommit Missed",
 	})
-	totalMissedPrevotes = promauto.NewGauge(prometheus.GaugeOpts{
+	totalMissedPrevotes = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "signer_total_missed_prevotes",
 		Help: "Total Prevote Missed",
 	})

--- a/signer/raft_events.go
+++ b/signer/raft_events.go
@@ -46,6 +46,7 @@ func (s *RaftStore) getLeaderGRPCClient() (proto.CosignerGRPCClient, *grpc.Clien
 		time.Sleep(100 * time.Millisecond)
 	}
 	if leader == "" {
+		totalRaftLeaderElectiontimeout.Inc()
 		return nil, nil, errors.New("timed out waiting for leader election to complete")
 	}
 	conn, err := grpc.Dial(leader, grpc.WithTransportCredentials(insecure.NewCredentials()))

--- a/signer/raft_store.go
+++ b/signer/raft_store.go
@@ -90,6 +90,7 @@ func (s *RaftStore) init() error {
 	if err != nil {
 		return fmt.Errorf("failed to parse local address: %s, %v", host, err)
 	}
+	s.logger.Info("Local Raft Listening", "port", port)
 	sock, err := net.Listen("tcp", fmt.Sprintf(":%s", port))
 	if err != nil {
 		return err

--- a/signer/remote_signer.go
+++ b/signer/remote_signer.go
@@ -174,6 +174,7 @@ func (rs *ReconnRemoteSigner) handleSignVoteRequest(vote *tmProto.Vote) tmProtoP
 		totalPrecommitsSigned.Inc()
 	}
 	if vote.Type == tmProto.PrevoteType {
+		// Determine number of heights since the last Prevote
 		stepSize := vote.Height - previousPrevoteHeight
 		if previousPrevoteHeight != 0 && stepSize > 1 {
 			missedPrevotes.Add(float64(stepSize))
@@ -182,7 +183,7 @@ func (rs *ReconnRemoteSigner) handleSignVoteRequest(vote *tmProto.Vote) tmProtoP
 			missedPrevotes.Set(0)
 		}
 
-		previousPrevoteHeight = vote.Height
+		previousPrevoteHeight = vote.Height // remember last PrevoteHeight
 		previousPrevoteTime = time.Now()
 
 		lastPrevoteHeight.Set(float64(vote.Height))

--- a/signer/remote_signer.go
+++ b/signer/remote_signer.go
@@ -77,12 +77,14 @@ func (rs *ReconnRemoteSigner) loop() {
 			proto, address := tmNet.ProtocolAndAddress(rs.address)
 			netConn, err := rs.dialer.Dial(proto, address)
 			if err != nil {
+				sentryConnectTries.Add(float64(1))
 				totalSentryConnectTries.Inc()
 				rs.Logger.Error("Dialing", "err", err)
 				rs.Logger.Info("Retrying", "sleep (s)", 3, "address", rs.address)
 				time.Sleep(time.Second * 3)
 				continue
 			}
+			sentryConnectTries.Set(0)
 
 			rs.Logger.Info("Connected to Sentry", "address", rs.address)
 			conn, err = tmP2pConn.MakeSecretConnection(netConn, rs.privKey)

--- a/signer/remote_signer.go
+++ b/signer/remote_signer.go
@@ -171,9 +171,7 @@ func (rs *ReconnRemoteSigner) handleSignVoteRequest(vote *tmProto.Vote) tmProtoP
 		}
 		previousPrecommitHeight = vote.Height // remember last PrecommitHeight
 
-		metricsPeriodicUpdateMutex.Lock()
-		previousPrecommitTime = time.Now()
-		metricsPeriodicUpdateMutex.Unlock()
+		metricsTimeKeeper.SetPreviousPrecommit(time.Now())
 
 		lastPrecommitHeight.Set(float64(vote.Height))
 		lastPrecommitRound.Set(float64(vote.Round))
@@ -191,9 +189,7 @@ func (rs *ReconnRemoteSigner) handleSignVoteRequest(vote *tmProto.Vote) tmProtoP
 
 		previousPrevoteHeight = vote.Height // remember last PrevoteHeight
 
-		metricsPeriodicUpdateMutex.Lock()
-		previousPrevoteTime = time.Now()
-		metricsPeriodicUpdateMutex.Unlock()
+		metricsTimeKeeper.SetPreviousPrevote(time.Now())
 
 		lastPrevoteHeight.Set(float64(vote.Height))
 		lastPrevoteRound.Set(float64(vote.Round))

--- a/signer/remote_signer.go
+++ b/signer/remote_signer.go
@@ -169,8 +169,12 @@ func (rs *ReconnRemoteSigner) handleSignVoteRequest(vote *tmProto.Vote) tmProtoP
 		} else {
 			missedPrecommits.Set(0)
 		}
-		previousPrecommitHeight = vote.Height
+		previousPrecommitHeight = vote.Height // remember last PrecommitHeight
+
+		metricsPeriodicUpdateMutex.Lock()
 		previousPrecommitTime = time.Now()
+		metricsPeriodicUpdateMutex.Unlock()
+
 		lastPrecommitHeight.Set(float64(vote.Height))
 		lastPrecommitRound.Set(float64(vote.Round))
 		totalPrecommitsSigned.Inc()
@@ -186,7 +190,10 @@ func (rs *ReconnRemoteSigner) handleSignVoteRequest(vote *tmProto.Vote) tmProtoP
 		}
 
 		previousPrevoteHeight = vote.Height // remember last PrevoteHeight
+
+		metricsPeriodicUpdateMutex.Lock()
 		previousPrevoteTime = time.Now()
+		metricsPeriodicUpdateMutex.Unlock()
 
 		lastPrevoteHeight.Set(float64(vote.Height))
 		lastPrevoteRound.Set(float64(vote.Round))

--- a/signer/remote_signer.go
+++ b/signer/remote_signer.go
@@ -261,7 +261,10 @@ func StartRemoteSigners(services []tmService.Service, logger tmLog.Logger, chain
 	var err error
 	go StartMetrics()
 	for _, node := range nodes {
-		dialer := net.Dialer{Timeout: 30 * time.Second}
+		// Tendermint requires a connection within 3 seconds of start or crashes
+		// A long timeout such as 30 seconds would cause the sentry to fail in loops
+		// Use a short timeout and dial often to connect within 3 second window
+		dialer := net.Dialer{Timeout: 2 * time.Second}
 		s := NewReconnRemoteSigner(node.Address, logger, chainID, privVal, dialer)
 
 		err = s.Start()

--- a/signer/threshold_validator.go
+++ b/signer/threshold_validator.go
@@ -201,6 +201,7 @@ func (pv *ThresholdValidator) waitForPeerSetEphemeralSharesAndSign(
 	ephemeralPublic *[]byte,
 	wg *sync.WaitGroup,
 ) {
+	peerStartTime := time.Now()
 	defer wg.Done()
 	peerEphemeralSecretParts := make([]CosignerEphemeralSecretPart, 0, pv.threshold-1)
 	for _, EncryptedSecrets := range *encryptedEphemeralSharesThresholdMap {
@@ -233,6 +234,7 @@ func (pv *ThresholdValidator) waitForPeerSetEphemeralSharesAndSign(
 		return
 	}
 
+	timedCosignerSignLag.WithLabelValues(peer.GetAddress()).Observe(time.Since(peerStartTime).Seconds())
 	pv.logger.Debug(fmt.Sprintf("Received signature from %d", peerID))
 
 	shareSignaturesMutex.Lock()
@@ -290,6 +292,8 @@ func (pv *ThresholdValidator) getExistingBlockSignature(block *Block) ([]byte, t
 func (pv *ThresholdValidator) SignBlock(chainID string, block *Block) ([]byte, time.Time, error) {
 	height, round, step, stamp, signBytes := block.Height, block.Round, block.Step, block.Timestamp, block.SignBytes
 
+	timeStartSignBlock := time.Now()
+
 	// Only the leader can execute this function. Followers can handle the requests,
 	// but they just need to proxy the request to the raft leader
 	if pv.raftStore.raft == nil {
@@ -297,6 +301,7 @@ func (pv *ThresholdValidator) SignBlock(chainID string, block *Block) ([]byte, t
 	}
 	if pv.raftStore.raft.State() != raft.Leader {
 		pv.logger.Debug("I am not the raft leader. Proxying request to the leader")
+		totalNotRaftLeader.Inc()
 		signRes, err := pv.raftStore.LeaderSignBlock(CosignerSignBlockRequest{chainID, block})
 		if err != nil {
 			if _, ok := err.(*rpcTypes.RPCError); ok {
@@ -311,6 +316,7 @@ func (pv *ThresholdValidator) SignBlock(chainID string, block *Block) ([]byte, t
 		return signRes.Signature, stamp, nil
 	}
 
+	totalRaftLeader.Inc()
 	pv.logger.Debug("I am the raft leader. Managing the sign process for this block")
 
 	hrst := HRSTKey{
@@ -394,6 +400,7 @@ func (pv *ThresholdValidator) SignBlock(chainID string, block *Block) ([]byte, t
 	encryptedEphemeralSharesThresholdMap[pv.cosigner] = ourEphemeralSecretParts.EncryptedSecrets
 	thresholdPeersMutex.Unlock()
 
+	timedSignBlockThresholdLag.Observe(time.Since(timeStartSignBlock).Seconds())
 	pv.logger.Debug("Have threshold peers")
 
 	setEphemeralAndSignWaitGroup := sync.WaitGroup{}
@@ -421,6 +428,7 @@ func (pv *ThresholdValidator) SignBlock(chainID string, block *Block) ([]byte, t
 		return nil, stamp, errors.New("timed out waiting for peers to sign")
 	}
 
+	timedSignBlockCosignerLag.Observe(time.Since(timeStartSignBlock).Seconds())
 	pv.logger.Debug("Done waiting for cosigners, assembling signatures")
 
 	// collect all valid responses into array of ids and signatures for the threshold lib
@@ -438,6 +446,7 @@ func (pv *ThresholdValidator) SignBlock(chainID string, block *Block) ([]byte, t
 	}
 
 	if len(sigIds) < pv.threshold {
+		totalInsufficientCosigners.Inc()
 		return nil, stamp, errors.New("not enough co-signers")
 	}
 
@@ -449,6 +458,7 @@ func (pv *ThresholdValidator) SignBlock(chainID string, block *Block) ([]byte, t
 
 	// verify the combined signature before saving to watermark
 	if !pv.pubkey.VerifySignature(signBytes, signature) {
+		totalInvalidSignature.Inc()
 		return nil, stamp, errors.New("combined signature is not valid")
 	}
 
@@ -472,6 +482,9 @@ func (pv *ThresholdValidator) SignBlock(chainID string, block *Block) ([]byte, t
 	if err != nil {
 		pv.logger.Error("Error emitting LSS", err.Error())
 	}
+
+	timeSignBlock := time.Since(timeStartSignBlock).Seconds()
+	timedSignBlockLag.Observe(timeSignBlock)
 
 	return signature, stamp, nil
 }

--- a/signer/threshold_validator.go
+++ b/signer/threshold_validator.go
@@ -176,6 +176,7 @@ func (pv *ThresholdValidator) waitForPeerEphemeralShares(
 	encryptedEphemeralSharesThresholdMap *map[Cosigner][]CosignerEphemeralSecretPart,
 	thresholdPeersMutex *sync.Mutex,
 ) {
+	peerStartTime := time.Now()
 	ephemeralSecretParts, err := peer.GetEphemeralSecretParts(hrst)
 	if err != nil {
 
@@ -187,6 +188,7 @@ func (pv *ThresholdValidator) waitForPeerEphemeralShares(
 	}
 	// Significant missing shares may lead to signature failure
 	missedEphemeralShares.WithLabelValues(peer.GetAddress()).Set(0)
+	timedCosignerEphemeralShareLag.WithLabelValues(peer.GetAddress()).Observe(time.Since(peerStartTime).Seconds())
 
 	// Check so that getEphemeralWaitGroup.Done is not called more than (threshold - 1) times which causes hardlock
 	thresholdPeersMutex.Lock()


### PR DESCRIPTION
## Description

This PR addresses basic prometheus metrics mentioned in https://github.com/strangelove-ventures/horcrux/issues/11

This covers latest signed height/round, latest/missed heights, sentry dial failure counts.

## Checklist

- [X] I have made sure the upstream branch for this PR is correct
- [X] I have made sure this PR is ready to merge
- [X] I have made sure that I have assigned reviewers related to this project

## Changes

- [X] Added Basic Prometheus Metrics
- [X] Prevents Sentry boot crash loops with shorter dial timeouts.  Helpful when Sentry has long start times (full nodes)
- [X] Code upgrades for go 1.16 deprecations
- [X] Fixed formatting/lint issues for existing code

## Single Signer Testing

- Start Horcrux
- Wait
- curl http://localhost:2112/metrics
- Look at 'signer_total_sentry_connect_tries' increase
- Start Validator
- Wait
- Look at 'signer_last_precommit_height' increase
- Look at 'signer_last_prevote_height' increase
- Stop validator
- Look at 'signer_seconds_since_last_precommit' increase
- Look at 'signer_seconds_since_last_prevote' increase
- Wait 60 seconds
- Start validator
- Look at 'signer_missed_prevotes' increase
- Wait for validator to sync
- Look at 'signer_total_missed_prevotes' increase
- Look at 'signer_total_missed_precommits' increase

## Co-Signer Testing

- Look at docs/metrics.md to see key metrics to monitor
- Specifically 'signer_seconds_since_last_local_ephemeral_share_time' will indicate when a cosigner node is not contacted
- Stop 2 of 3 nodes and watch the last node signer_seconds_since_last_local_ephemeral_share_time increase

## Notes


Feedback welcome in general

Prefer to address any raft p2p specific / additional metrics on a separate commit/PR

This PR focuses on what can be seen outside the raft P2P layer


There are some lint failures with fixes in an isolated commit, but it is mostly related to existing leading spaces in boilerplate apache license comments or for comment clarity.

In addition, gofmt with -s or -w options on the flagged files does not produce any differences.

```
cmd/horcrux/main.go:8: File is not `gofmt`-ed with `-s` (gofmt)
    http://www.apache.org/licenses/LICENSE-2.0
cmd/horcrux/cmd/key2shares.go:8: File is not `gofmt`-ed with `-s` (gofmt)
    http://www.apache.org/licenses/LICENSE-2.0
cmd/horcrux/cmd/version.go:8: File is not `gofmt`-ed with `-s` (gofmt)
    http://www.apache.org/licenses/LICENSE-2.0
test/test_signer.go:120: File is not `gofmt`-ed with `-s` (gofmt)
//       same sentry node.
```

Removed the spaces in my last commit to reduce chances of human PR rejection, but I think it's more a "bug" or configuration issue in the linter.
