### PR TITLE
pin to golang:1.19-alpine

### DIFF
--- a/docker/horcrux/Dockerfile
+++ b/docker/horcrux/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.19.1-alpine3.16 AS build-env
+FROM --platform=$BUILDPLATFORM golang:1.19-alpine AS build-env
 
 ENV PACKAGES make git
 

--- a/docker/horcrux/native.Dockerfile
+++ b/docker/horcrux/native.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.1-alpine3.16 AS build-env
+FROM golang:1.19-alpine AS build-env
 
 ENV PACKAGES make git
 


### PR DESCRIPTION
From @mark-rushakoff 
> I usually just specify golang:1.19-alpine so that we automatically use the latest patch release without having to update this file.
Generally, we would want to adopt go 1.19. as soon as it's available.

Updated to the dynamic 1.19-alpine tag