### PR TITLE
Fix ipv6 leader election

### DIFF
--- a/cmd/horcrux/cmd/leader_election.go
+++ b/cmd/horcrux/cmd/leader_election.go
@@ -48,16 +48,24 @@ horcrux elect 2 # elect specific leader`,
 		}
 
 		var grpcAddresses []string
+
+		// Append local host:port
 		u, err := url.Parse(config.Config.CosignerConfig.P2PListen)
 		if err != nil {
 			fmt.Printf("Error parsing peer URL: %v", err)
 		} else {
 			host, port, err := net.SplitHostPort(u.Host)
 			if err == nil {
-				grpcAddresses = append(grpcAddresses, fmt.Sprintf("%s:%s", host, port))
+				if strings.Contains(host, ":") {
+					// IPv6 Addreses need to be wrapped in brackets
+					grpcAddresses = append(grpcAddresses, fmt.Sprintf("[%s]:%s", host, port))
+				} else {
+					grpcAddresses = append(grpcAddresses, fmt.Sprintf("%s:%s", host, port))
+				}
 			}
 		}
 
+		// Append peer host:port
 		for _, peer := range config.Config.CosignerConfig.Peers {
 			u, err := url.Parse(peer.P2PAddr)
 			if err != nil {
@@ -65,7 +73,12 @@ horcrux elect 2 # elect specific leader`,
 			} else {
 				host, port, err := net.SplitHostPort(u.Host)
 				if err == nil {
-					grpcAddresses = append(grpcAddresses, fmt.Sprintf("%s:%s", host, port))
+					if strings.Contains(host, ":") {
+						// IPv6 Addreses need to be wrapped in brackets
+						grpcAddresses = append(grpcAddresses, fmt.Sprintf("[%s]:%s", host, port))
+					} else {
+						grpcAddresses = append(grpcAddresses, fmt.Sprintf("%s:%s", host, port))
+					}
 				}
 			}
 		}


### PR DESCRIPTION
<!-- markdownlint-disable MD014 MD033 MD034 MD036 MD041 -->

## Description

Fixes https://github.com/strangelove-ventures/horcrux/issues/91

## Checklist

- [X] I have made sure the upstream branch for this PR is correct
- [X] I have made sure this PR is ready to merge
- [ ] I have made sure that I have assigned reviewers related to this project

## Changes

Updated string parsing to wrap IPv6 Addresses in [] to distinguish from port

## Testing

Set up horcrux 2 of 3 signing cluster using IPv6 Peer Addresses

horcrux elect 1
horcrux elect 2
horcrux elect 3

## Comments

Purposely did not import a big external dependency to validate IPv4/6 addresses with the assumption that a running cluster likely already has a well formatted and valid configuration file.
