### PR TITLE
chore: buldflag `trimpath` & ldflags `-s -w` to slim binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ all: install
 LD_FLAGS = -X github.com/strangelove-ventures/horcrux/cmd/horcrux/cmd.Version=$(VERSION) \
 	-X github.com/strangelove-ventures/horcrux/cmd/horcrux/cmd.Commit=$(COMMIT)
 
-BUILD_FLAGS := -ldflags '$(LD_FLAGS)'
+BUILD_FLAGS := -trimpath -ldflags '-s -w $(LD_FLAGS)'
 
 build:
 	@go build -mod readonly $(BUILD_FLAGS) -o build/ ./cmd/horcrux/...


### PR DESCRIPTION
<!-- markdownlint-disable MD014 MD033 MD034 MD036 MD041 -->

## Description

Add go build flag `-trimpath` and ldflags `-s -w` in Makefile to save around **5MB** in binary size, more about flags [here go link](https://pkg.go.dev/cmd/link) and [here go build](https://pkg.go.dev/cmd/go)


## Checklist

- [x] I have made sure the upstream branch for this PR is correct
- [ ] I have made sure this PR is ready to merge
- [ ] I have made sure that I have assigned reviewers related to this project

## Changes

- [x] Add go build flag `-trimpath` and ldflags `-s -w` in Makefile

## Screenshots

NA

## Testing

- Remain from CI side

## Links/References

- https://pkg.go.dev/cmd/go
- https://pkg.go.dev/cmd/link

## Notes

NA
