### PR TITLE
Add logs for participating cosigners

### DIFF
--- a/signer/grpc_server.go
+++ b/signer/grpc_server.go
@@ -44,8 +44,14 @@ func (rpc *GRPCServer) SetEphemeralSecretPartsAndSign(
 		SignBytes:        req.GetSignBytes(),
 	})
 	if err != nil {
+		rpc.raftStore.logger.Error("Failed to sign with share", "error", err)
 		return nil, err
 	}
+	rpc.raftStore.logger.Info("Signed with share",
+		"height", req.Hrst.Height,
+		"round", req.Hrst.Round,
+		"step", req.Hrst.Step,
+	)
 	return &proto.CosignerGRPCSetEphemeralSecretPartsAndSignResponse{
 		EphemeralPublic: res.EphemeralPublic,
 		Timestamp:       res.Timestamp.UnixNano(),


### PR DESCRIPTION
When a cosigner is not receiving block sign requests directly from a sentry, there is no log output. This is confusing because it appears as if the cosigner is not participating in signing blocks.

This adds logs for cosigner share signature success/fail to indicate cosigner participation even if it is not receiving block sign requests from a sentry.