### PR TITLE
Add signature and timestamp to log for adjusted timestamp visibility

### DIFF
--- a/signer/remote_signer.go
+++ b/signer/remote_signer.go
@@ -159,8 +159,9 @@ func (rs *ReconnRemoteSigner) handleSignVoteRequest(vote *tmProto.Vote) tmProtoP
 		msgSum.SignedVoteResponse.Error = getRemoteSignerError(err)
 		return tmProtoPrivval.Message{Sum: msgSum}
 	}
-	// Show that the signatures provided to each node have the same signature and timestamps for peace of mind
-	rs.Logger.Info("Signed vote", "height", vote.Height, "round", vote.Round, "type", vote.Type, "sig", vote.Signature[:6], "ts", vote.Timestamp.Unix(), "node", rs.address)
+	// Show signatures provided to each node have the same signature and timestamps
+	rs.Logger.Info("Signed vote", "height", vote.Height, "round", vote.Round, "type", vote.Type,
+		"sig", vote.Signature[:6], "ts", vote.Timestamp.Unix(), "node", rs.address)
 
 	if vote.Type == tmProto.PrecommitType {
 		stepSize := vote.Height - previousPrecommitHeight

--- a/signer/remote_signer.go
+++ b/signer/remote_signer.go
@@ -160,8 +160,12 @@ func (rs *ReconnRemoteSigner) handleSignVoteRequest(vote *tmProto.Vote) tmProtoP
 		return tmProtoPrivval.Message{Sum: msgSum}
 	}
 	// Show signatures provided to each node have the same signature and timestamps
+	sigLen := 6
+	if len(vote.Signature) < sigLen {
+		sigLen = len(vote.Signature)
+	}
 	rs.Logger.Info("Signed vote", "height", vote.Height, "round", vote.Round, "type", vote.Type,
-		"sig", vote.Signature[:6], "ts", vote.Timestamp.Unix(), "node", rs.address)
+		"sig", vote.Signature[:sigLen], "ts", vote.Timestamp.Unix(), "node", rs.address)
 
 	if vote.Type == tmProto.PrecommitType {
 		stepSize := vote.Height - previousPrecommitHeight

--- a/signer/remote_signer.go
+++ b/signer/remote_signer.go
@@ -159,7 +159,8 @@ func (rs *ReconnRemoteSigner) handleSignVoteRequest(vote *tmProto.Vote) tmProtoP
 		msgSum.SignedVoteResponse.Error = getRemoteSignerError(err)
 		return tmProtoPrivval.Message{Sum: msgSum}
 	}
-	rs.Logger.Info("Signed vote", "node", rs.address, "height", vote.Height, "round", vote.Round, "type", vote.Type)
+	// Show that the signatures provided to each node have the same signature and timestamps for peace of mind
+	rs.Logger.Info("Signed vote", "height", vote.Height, "round", vote.Round, "type", vote.Type, "sig", vote.Signature[:6], "ts", vote.Timestamp.Unix(), "node", rs.address)
 
 	if vote.Type == tmProto.PrecommitType {
 		stepSize := vote.Height - previousPrecommitHeight


### PR DESCRIPTION
## Description

Seeing Horcrux logs sending signatures to multiple nodes visually appears to be potentially a Double Sign.

Print the vote signature prefix and timestamp to show the result provided is the same to reduce human operator panic.

Moved node to the end for easy visual checks of signature equality

## Checklist

- [X] I have made sure the upstream branch for this PR is correct
- [X] I have made sure this PR is ready to merge
- [ ] I have made sure that I have assigned reviewers related to this project

## Changes

- [X] Added signature and timestamp logging

## Screenshots

```
Signed vote                                  module=validator height=653101 round=0 type=SIGNED_MSG_TYPE_PREVOTE sig=4F709E6B9AE7 ts=1667684648 node=tcp://10.1.1.1:1111
Signed vote                                  module=validator height=653101 round=0 type=SIGNED_MSG_TYPE_PREVOTE sig=4F709E6B9AE7 ts=1667684648 node=tcp://10.1.1.1:1112
Signed vote                                  module=validator height=653101 round=0 type=SIGNED_MSG_TYPE_PREVOTE sig=4F709E6B9AE7 ts=1667684648 node=tcp://10.1.1.1:1113
Signed vote                                  module=validator height=653101 round=0 type=SIGNED_MSG_TYPE_PRECOMMIT sig=00DB7E882197 ts=1667684648 node=tcp://10.1.1.1:1111
Signed vote                                  module=validator height=653101 round=0 type=SIGNED_MSG_TYPE_PRECOMMIT sig=00DB7E882197 ts=1667684648 node=tcp://10.1.1.1:1112
Signed vote                                  module=validator height=653101 round=0 type=SIGNED_MSG_TYPE_PRECOMMIT sig=00DB7E882197 ts=1667684648 node=tcp://10.1.1.1:1113
...

