### PR TITLE
Wait for sign state flush on stop

### DIFF
--- a/cmd/horcrux/cmd/cosigner.go
+++ b/cmd/horcrux/cmd/cosigner.go
@@ -14,7 +14,6 @@ import (
 	"github.com/strangelove-ventures/horcrux/signer"
 	tmlog "github.com/tendermint/tendermint/libs/log"
 	tmService "github.com/tendermint/tendermint/libs/service"
-	"github.com/tendermint/tendermint/types"
 )
 
 func cosignerCmd() *cobra.Command {
@@ -121,7 +120,6 @@ func startCosignerCmd() *cobra.Command {
 			var (
 				// services to stop on shutdown
 				services []tmService.Service
-				pv       types.PrivValidator
 				logger   = tmlog.NewTMLogger(tmlog.NewSyncWriter(os.Stdout)).With("module", "validator")
 			)
 
@@ -132,8 +130,6 @@ func startCosignerCmd() *cobra.Command {
 
 			logger.Info("Tendermint Validator", "mode", "threshold",
 				"priv-key", config.Config.PrivValKeyFile, "priv-state-dir", config.StateDir)
-
-			var val types.PrivValidator
 
 			key, err := signer.LoadCosignerKey(keyFile)
 			if err != nil {
@@ -209,7 +205,7 @@ func startCosignerCmd() *cobra.Command {
 			}
 			services = append(services, raftStore)
 
-			val = signer.NewThresholdValidator(
+			val := signer.NewThresholdValidator(
 				logger,
 				&config,
 				key.PubKey,
@@ -220,9 +216,9 @@ func startCosignerCmd() *cobra.Command {
 				raftStore,
 			)
 
-			raftStore.SetThresholdValidator(val.(*signer.ThresholdValidator))
+			raftStore.SetThresholdValidator(val)
 
-			pv = &signer.PvGuard{PrivValidator: val}
+			pv := &signer.PvGuard{PrivValidator: val}
 
 			pubkey, err := pv.GetPubKey()
 			if err != nil {

--- a/cmd/horcrux/cmd/state.go
+++ b/cmd/horcrux/cmd/state.go
@@ -112,12 +112,12 @@ func setStateCmd() *cobra.Command {
 				Signature: nil,
 				SignBytes: nil,
 			}
-			err = pv.Save(signState, nil, false)
+			err = pv.Save(signState, nil, nil)
 			if err != nil {
 				fmt.Printf("error saving privval sign state")
 				return err
 			}
-			err = share.Save(signState, nil, false)
+			err = share.Save(signState, nil, nil)
 			if err != nil {
 				fmt.Printf("error saving share sign state")
 				return err
@@ -200,12 +200,12 @@ func importStateCmd() *cobra.Command {
 				"  Step:      %v\n",
 				signState.Height, signState.Round, signState.Step)
 
-			err = pv.Save(signState, nil, false)
+			err = pv.Save(signState, nil, nil)
 			if err != nil {
 				fmt.Printf("error saving privval sign state")
 				return err
 			}
-			err = share.Save(signState, nil, false)
+			err = share.Save(signState, nil, nil)
 			if err != nil {
 				fmt.Printf("error saving share sign state")
 				return err

--- a/cmd/horcrux/cmd/state.go
+++ b/cmd/horcrux/cmd/state.go
@@ -112,12 +112,12 @@ func setStateCmd() *cobra.Command {
 				Signature: nil,
 				SignBytes: nil,
 			}
-			err = pv.Save(signState, nil, nil)
+			err = pv.Save(signState, nil)
 			if err != nil {
 				fmt.Printf("error saving privval sign state")
 				return err
 			}
-			err = share.Save(signState, nil, nil)
+			err = share.Save(signState, nil)
 			if err != nil {
 				fmt.Printf("error saving share sign state")
 				return err
@@ -200,12 +200,12 @@ func importStateCmd() *cobra.Command {
 				"  Step:      %v\n",
 				signState.Height, signState.Round, signState.Step)
 
-			err = pv.Save(signState, nil, nil)
+			err = pv.Save(signState, nil)
 			if err != nil {
 				fmt.Printf("error saving privval sign state")
 				return err
 			}
-			err = share.Save(signState, nil, nil)
+			err = share.Save(signState, nil)
 			if err != nil {
 				fmt.Printf("error saving share sign state")
 				return err

--- a/signer/PvGuard.go
+++ b/signer/PvGuard.go
@@ -8,6 +8,8 @@ import (
 	tm "github.com/tendermint/tendermint/types"
 )
 
+var _ PrivValidator = &PvGuard{}
+
 // PvGuard guards access to an underlying PrivValidator by using mutexes
 // for each of the PrivValidator interface functions
 type PvGuard struct {
@@ -15,23 +17,26 @@ type PvGuard struct {
 	pvMutex       sync.Mutex
 }
 
-// GetPubKey implements types.PrivValidator
+// GetPubKey implements PrivValidator
 func (pv *PvGuard) GetPubKey() (crypto.PubKey, error) {
 	pv.pvMutex.Lock()
 	defer pv.pvMutex.Unlock()
 	return pv.PrivValidator.GetPubKey()
 }
 
-// SignVote implements types.PrivValidator
+// SignVote implements PrivValidator
 func (pv *PvGuard) SignVote(chainID string, vote *tmProto.Vote) error {
 	pv.pvMutex.Lock()
 	defer pv.pvMutex.Unlock()
 	return pv.PrivValidator.SignVote(chainID, vote)
 }
 
-// SignProposal implements types.PrivValidator
+// SignProposal implements PrivValidator
 func (pv *PvGuard) SignProposal(chainID string, proposal *tmProto.Proposal) error {
 	pv.pvMutex.Lock()
 	defer pv.pvMutex.Unlock()
 	return pv.PrivValidator.SignProposal(chainID, proposal)
 }
+
+// SignProposal implements PrivValidator
+func (pv *PvGuard) Stop() {}

--- a/signer/local_cosigner_test.go
+++ b/signer/local_cosigner_test.go
@@ -113,6 +113,7 @@ func TestLocalCosignerSign2of2(t *testing.T) {
 		total,
 		threshold,
 	)
+	defer cosigner1.waitForSignStatesToFlushToDisk()
 	cosigner2 := NewLocalCosigner(
 		&RuntimeConfig{},
 		key2,
@@ -123,6 +124,7 @@ func TestLocalCosignerSign2of2(t *testing.T) {
 		total,
 		threshold,
 	)
+	defer cosigner2.waitForSignStatesToFlushToDisk()
 
 	require.Equal(t, cosigner1.GetID(), 1)
 	require.Equal(t, cosigner2.GetID(), 2)

--- a/signer/services.go
+++ b/signer/services.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"sync"
 	"syscall"
 
 	tmLog "github.com/tendermint/tendermint/libs/log"
@@ -69,8 +68,7 @@ manual deletion of PID file required`, pidFilePath, pid)
 }
 
 func WaitAndTerminate(logger tmLog.Logger, services []tmService.Service, pidFilePath string) {
-	wg := sync.WaitGroup{}
-	wg.Add(1)
+	done := make(chan struct{})
 
 	pidFile, err := os.OpenFile(pidFilePath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
 	if err != nil {
@@ -91,7 +89,7 @@ func WaitAndTerminate(logger tmLog.Logger, services []tmService.Service, pidFile
 				panic(err)
 			}
 		}
-		wg.Done()
+		close(done)
 	})
-	wg.Wait()
+	<-done
 }

--- a/signer/sign_state.go
+++ b/signer/sign_state.go
@@ -107,7 +107,7 @@ func (signState *SignState) GetFromCache(hrs HRSKey, lock *sync.Mutex) (HRSKey, 
 	return latestBlock, nil
 }
 
-// Save will update the high watermark height/round/step (HRS) if it is greater
+// Save updates the high watermark height/round/step (HRS) if it is greater
 // than the current high watermark. If pendingDiskWG is provided, the write operation
 // will be a separate goroutine (async). This allows pendingDiskWG to be used to .Wait()
 // for all pending SignState disk writes.

--- a/signer/threshold_signer.go
+++ b/signer/threshold_signer.go
@@ -24,6 +24,8 @@ type ThresholdSigner interface {
 	Sign(req CosignerSignRequest, m *LastSignStateWrapper) (CosignerSignResponse, error)
 
 	GetID() (int, error)
+
+	Stop()
 }
 
 // PeerMetadata holds the share and the ephermeral secret public key

--- a/signer/threshold_signer.go
+++ b/signer/threshold_signer.go
@@ -25,7 +25,7 @@ type ThresholdSigner interface {
 
 	GetID() (int, error)
 
-	// Stop should perform any cleanup work, such as flushing state files to disk, then shut down.
+	// Stop performs any cleanup work, such as flushing state files to disk, then shut down.
 	Stop()
 }
 

--- a/signer/threshold_signer.go
+++ b/signer/threshold_signer.go
@@ -25,6 +25,7 @@ type ThresholdSigner interface {
 
 	GetID() (int, error)
 
+	// Stop should perform any cleanup work, such as flushing state files to disk, then shut down.
 	Stop()
 }
 

--- a/signer/threshold_signer_soft.go
+++ b/signer/threshold_signer_soft.go
@@ -27,7 +27,7 @@ type ThresholdSignerSoft struct {
 	// Height, Round, Step, Timestamp --> metadata
 	hrsMeta map[HRSTKey]HrsMetadata
 
-	asyncWaitGroup sync.WaitGroup
+	pendingDiskWG sync.WaitGroup
 }
 
 // NewThresholdSignerSoft constructs a ThresholdSigner
@@ -54,7 +54,7 @@ func (softSigner *ThresholdSignerSoft) Stop() {
 }
 
 func (softSigner *ThresholdSignerSoft) waitForSignStatesToFlushToDisk() {
-	softSigner.asyncWaitGroup.Wait()
+	softSigner.pendingDiskWG.Wait()
 }
 
 // Implements ThresholdSigner
@@ -140,7 +140,7 @@ func (softSigner *ThresholdSignerSoft) Sign(
 		Step:      hrst.Step,
 		Signature: sig,
 		SignBytes: req.SignBytes,
-	}, nil, &softSigner.asyncWaitGroup)
+	}, &softSigner.pendingDiskWG)
 	if err != nil {
 		var isSameHRSError *SameHRSError
 		if !errors.As(err, &isSameHRSError) {

--- a/signer/threshold_validator_test.go
+++ b/signer/threshold_validator_test.go
@@ -121,6 +121,7 @@ func TestThresholdValidator2of2(t *testing.T) {
 		thresholdPeers,
 		raftStore,
 	)
+	defer validator.Stop()
 
 	raftStore.SetThresholdValidator(validator)
 
@@ -258,6 +259,7 @@ func TestThresholdValidator3of3(t *testing.T) {
 		thresholdPeers,
 		raftStore,
 	)
+	defer validator.Stop()
 
 	raftStore.SetThresholdValidator(validator)
 
@@ -398,6 +400,7 @@ func TestThresholdValidator2of3(t *testing.T) {
 		thresholdPeers,
 		raftStore,
 	)
+	defer validator.Stop()
 
 	raftStore.SetThresholdValidator(validator)
 


### PR DESCRIPTION
On process termination (and test completion), wait for async sign state writes to complete before shutting down.

Cleanup unnecessary `sync.WaitGroup` in `WaitAndTerminate`, replace with simple chan.