### PR TITLE
tidy up usage and flags

### DIFF
--- a/cmd/horcrux/cmd/address.go
+++ b/cmd/horcrux/cmd/address.go
@@ -31,6 +31,8 @@ func addressCmd() *cobra.Command {
 
 			var pubKey crypto.PubKey
 
+			chainID := args[0]
+
 			switch config.Config.SignMode {
 			case signer.SignModeThreshold:
 				err := config.Config.ValidateThresholdModeConfig()
@@ -38,14 +40,14 @@ func addressCmd() *cobra.Command {
 					return err
 				}
 
-				keyFile, err := config.KeyFileExistsCosigner(args[0])
+				keyFile, err := config.KeyFileExistsCosigner(chainID)
 				if err != nil {
 					return err
 				}
 
 				key, err := signer.LoadCosignerEd25519Key(keyFile)
 				if err != nil {
-					return fmt.Errorf("error reading cosigner key: %s", err)
+					return fmt.Errorf("error reading cosigner key: %w, check that key is present for chain ID: %s", err, chainID)
 				}
 
 				pubKey = key.PubKey
@@ -54,9 +56,9 @@ func addressCmd() *cobra.Command {
 				if err != nil {
 					return err
 				}
-				keyFile, err := config.KeyFileExistsSingleSigner(args[0])
+				keyFile, err := config.KeyFileExistsSingleSigner(chainID)
 				if err != nil {
-					return err
+					return fmt.Errorf("error reading priv-validator key: %w, check that key is present for chain ID: %s", err, chainID)
 				}
 
 				filePV := cometprivval.LoadFilePVEmptyState(keyFile, "")

--- a/cmd/horcrux/cmd/config.go
+++ b/cmd/horcrux/cmd/config.go
@@ -125,7 +125,8 @@ for threshold signer mode, --cosigner flags and --threshold flag are required.
 
 	f := cmd.Flags()
 	f.StringP(flagSignMode, "m", string(signer.SignModeThreshold),
-		`sign mode, "threshold" (recommended) or "single" (unsupported). threshold mode requires --cosigners and --threshold`,
+		"sign mode, \"threshold\" (recommended) or \"single\" (unsupported). "+
+			"threshold mode requires --cosigner flags and --threshold flag",
 	)
 	f.StringSliceP(flagNode, "n", []string{}, "chain nodes in format tcp://{node-addr}:{privval-port} \n"+
 		"(e.g. --node tcp://sentry-1:1234 --node tcp://sentry-2:1234 --node tcp://sentry-3:1234 )")

--- a/cmd/horcrux/cmd/config.go
+++ b/cmd/horcrux/cmd/config.go
@@ -33,12 +33,12 @@ func configCmd() *cobra.Command {
 
 func initCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "init [chain-nodes]",
+		Use:     "init",
 		Aliases: []string{"i"},
 		Short:   "initialize configuration file and home directory if one doesn't already exist",
-		Long: "initialize configuration file, use flags for cosigner configuration.\n\n" +
-			"[chain-nodes] is a comma separated array of chain node addresses i.e.\n" +
-			"tcp://chain-node-1:1234,tcp://chain-node-2:1234",
+		Long: `initialize configuration file.
+for threshold signer mode, --cosigner flags and --threshold flag are required.
+		`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			cmdFlags := cmd.Flags()
@@ -122,23 +122,30 @@ func initCmd() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringP(flagSignMode, "m", string(signer.SignModeThreshold),
+
+	f := cmd.Flags()
+	f.StringP(flagSignMode, "m", string(signer.SignModeThreshold),
 		`sign mode, "threshold" (recommended) or "single" (unsupported). threshold mode requires --cosigners and --threshold`,
 	)
-	cmd.Flags().StringSliceP(flagNode, "n", []string{}, "chain nodes in format tcp://{p2p-addr}:{port}")
-	cmd.Flags().StringSliceP(flagCosigner, "c", []string{},
-		"cosigners in format tcp://{p2p-addr}:{port}|{shard-id} \n"+
-			"(i.e. \"tcp://node-1:2222|1,tcp://node-2:2222|2,tcp://node-3:2222|3\")")
-	cmd.Flags().IntP(flagThreshold, "t", 0, "number of shards required for threshold signature")
-	cmd.Flags().StringP(
+	f.StringSliceP(flagNode, "n", []string{}, "chain nodes in format tcp://{node-addr}:{privval-port} \n"+
+		"(e.g. --node tcp://sentry-1:1234 --node tcp://sentry-2:1234 --node tcp://sentry-3:1234 )")
+	_ = cmd.MarkFlagRequired(flagNode)
+
+	f.StringSliceP(flagCosigner, "c", []string{},
+		"cosigners in format tcp://{cosigner-addr}:{p2p-port} \n"+
+			"(e.g. --cosigner tcp://horcrux-1:2222 --cosigner tcp://horcrux-2:2222 --cosigner tcp://horcrux-3:2222 )")
+
+	f.IntP(flagThreshold, "t", 0, "number of shards required for threshold signature")
+
+	f.StringP(
 		flagDebugAddr, "d", "",
 		"listen address for debug server and prometheus metrics in format localhost:8543",
 	)
-	cmd.Flags().StringP(flagKeyDir, "k", "", "key directory if other than home directory")
-	cmd.Flags().String(flagRaftTimeout, "1500ms", "cosigner raft timeout value, \n"+
+	f.StringP(flagKeyDir, "k", "", "key directory if other than home directory")
+	f.String(flagRaftTimeout, "1500ms", "cosigner raft timeout value, \n"+
 		"accepts valid duration strings for Go's time.ParseDuration() e.g. 1s, 1000ms, 1.5m")
-	cmd.Flags().String(flagGRPCTimeout, "1500ms", "cosigner grpc timeout value, \n"+
+	f.String(flagGRPCTimeout, "1500ms", "cosigner grpc timeout value, \n"+
 		"accepts valid duration strings for Go's time.ParseDuration() e.g. 1s, 1000ms, 1.5m")
-	cmd.Flags().BoolP(flagOverwrite, "o", false, "overwrite an existing config.yaml")
+	f.BoolP(flagOverwrite, "o", false, "overwrite an existing config.yaml")
 	return cmd
 }

--- a/cmd/horcrux/cmd/config.go
+++ b/cmd/horcrux/cmd/config.go
@@ -125,16 +125,15 @@ for threshold signer mode, --cosigner flags and --threshold flag are required.
 
 	f := cmd.Flags()
 	f.StringP(flagSignMode, "m", string(signer.SignModeThreshold),
-		"sign mode, \"threshold\" (recommended) or \"single\" (unsupported). "+
-			"threshold mode requires --cosigner flags and --threshold flag",
+		`sign mode, "threshold" (recommended) or "single" (unsupported). threshold mode requires --cosigner (multiple) and --threshold`, //nolint
 	)
 	f.StringSliceP(flagNode, "n", []string{}, "chain nodes in format tcp://{node-addr}:{privval-port} \n"+
 		"(e.g. --node tcp://sentry-1:1234 --node tcp://sentry-2:1234 --node tcp://sentry-3:1234 )")
 	_ = cmd.MarkFlagRequired(flagNode)
 
 	f.StringSliceP(flagCosigner, "c", []string{},
-		"cosigners in format tcp://{cosigner-addr}:{p2p-port} \n"+
-			"(e.g. --cosigner tcp://horcrux-1:2222 --cosigner tcp://horcrux-2:2222 --cosigner tcp://horcrux-3:2222 )")
+		`cosigners in format tcp://{cosigner-addr}:{p2p-port}
+(e.g. --cosigner tcp://horcrux-1:2222 --cosigner tcp://horcrux-2:2222 --cosigner tcp://horcrux-3:2222)`)
 
 	f.IntP(flagThreshold, "t", 0, "number of shards required for threshold signature")
 

--- a/cmd/horcrux/cmd/config_test.go
+++ b/cmd/horcrux/cmd/config_test.go
@@ -46,6 +46,7 @@ thresholdMode:
 chainNodes:
 - privValAddr: tcp://10.168.0.1:1234
 - privValAddr: tcp://10.168.0.2:1234
+debugAddr: ""
 `,
 		},
 		{
@@ -60,6 +61,7 @@ chainNodes:
 chainNodes:
 - privValAddr: tcp://10.168.0.1:1234
 - privValAddr: tcp://10.168.0.2:1234
+debugAddr: ""
 `,
 		},
 		{

--- a/cmd/horcrux/cmd/state.go
+++ b/cmd/horcrux/cmd/state.go
@@ -74,7 +74,7 @@ func showStateCmd() *cobra.Command {
 
 func setStateCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:          "set [chain-id] [height]",
+		Use:          "set chain-id height",
 		Aliases:      []string{"s"},
 		Short:        "Set the height for the sign state of a specific chain-id",
 		Args:         cobra.ExactArgs(2),
@@ -136,7 +136,7 @@ func setStateCmd() *cobra.Command {
 
 func importStateCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:     "import [chain-id]",
+		Use:     "import chain-id",
 		Aliases: []string{"i"},
 		Short: "Read the old priv_validator_state.json and set the height, round and step" +
 			"(good for migrations but NOT shared state update)",

--- a/cmd/horcrux/cmd/testdata/config-migrated.yaml
+++ b/cmd/horcrux/cmd/testdata/config-migrated.yaml
@@ -14,3 +14,4 @@ chainNodes:
 - privValAddr: tcp://127.0.0.1:1234
 - privValAddr: tcp://127.0.0.1:2345
 - privValAddr: tcp://127.0.0.1:3456
+debugAddr: ""

--- a/signer/config.go
+++ b/signer/config.go
@@ -33,8 +33,8 @@ type Config struct {
 	PrivValKeyDir       *string              `yaml:"keyDir,omitempty"`
 	SignMode            SignMode             `yaml:"signMode"`
 	ThresholdModeConfig *ThresholdModeConfig `yaml:"thresholdMode,omitempty"`
-	ChainNodes          ChainNodes           `yaml:"chainNodes,omitempty"`
-	DebugAddr           string               `yaml:"debugAddr,omitempty"`
+	ChainNodes          ChainNodes           `yaml:"chainNodes"`
+	DebugAddr           string               `yaml:"debugAddr"`
 }
 
 func (c *Config) Nodes() (out []string) {
@@ -304,10 +304,11 @@ func (cns ChainNodes) Validate() error {
 	return errors.Join(errs...)
 }
 
-func ChainNodesFromFlag(nodes []string) (out ChainNodes, err error) {
-	for _, n := range nodes {
+func ChainNodesFromFlag(nodes []string) (ChainNodes, error) {
+	out := make(ChainNodes, len(nodes))
+	for i, n := range nodes {
 		cn := ChainNode{PrivValAddr: n}
-		out = append(out, cn)
+		out[i] = cn
 	}
 	if err := out.Validate(); err != nil {
 		return nil, err

--- a/signer/config_test.go
+++ b/signer/config_test.go
@@ -435,6 +435,7 @@ chainNodes:
 - privValAddr: tcp://127.0.0.1:1234
 - privValAddr: tcp://127.0.0.1:2345
 - privValAddr: tcp://127.0.0.1:3456
+debugAddr: ""
 `, string(configYamlBz))
 }
 


### PR DESCRIPTION
`horcrux address`
- give a more helpful error including the chain ID  if `horcrux address <chain-id>` fails to find they key

`horcrux config init`
- `[chain-nodes]` is not an optional argument, it is required with `--node` flag(s)
- clarify `--node` and `--cosigner` flags.

`horcrux create-rsa-shards`
- `shards` is not an argument, but a required flag

`horcrux create-ed25519-shards`
- all flags are required

`horcrux state set`
- `chain-id` and `height` are required args

`horcrux state import`
- `chain-id` is a required arg
