### PR TITLE
Make Horcrux a static executable

### DIFF
--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -16,6 +16,8 @@ builds:
     goarch:
       - amd64
       - arm64
+    env:
+      - CGO_ENABLED=0  
 
 checksum:
   name_template: SHA256SUMS-{{.Version}}.txt


### PR DESCRIPTION
Eliminating dependencies on system libraries by making the Horcrux binary static. 
This will fix #154 