### PR TITLE
Remove depguard

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,6 @@
 linters:
   enable:
     - bodyclose
-    - depguard
     - dogsled
     - goconst
     - gocritic


### PR DESCRIPTION
No config file for depguard exists . 
Removing this from .golangci.yml to get past lint failures in CI. 