### PR TITLE
sign state signaling

### DIFF
--- a/signer/hrs.go
+++ b/signer/hrs.go
@@ -30,19 +30,7 @@ func (hrs HRSKey) GreaterThan(other HRSKey) bool {
 
 // LessThan returns true if the HRSKey is less than the other HRSKey.
 func (hrs HRSKey) LessThan(other HRSKey) bool {
-	if hrs.Height < other.Height {
-		return true
-	}
-	if hrs.Height > other.Height {
-		return false
-	}
-	if hrs.Round < other.Round {
-		return true
-	}
-	if hrs.Round > other.Round {
-		return false
-	}
-	return hrs.Step < other.Step
+	return hrs != other && !hrs.GreaterThan(other)
 }
 
 // HRSTKey represents the HRS metadata key with a timestamp.

--- a/signer/hrs.go
+++ b/signer/hrs.go
@@ -1,0 +1,82 @@
+package signer
+
+import (
+	"github.com/strangelove-ventures/horcrux/signer/proto"
+)
+
+// HRSKey represents the key for the HRS metadata map.
+type HRSKey struct {
+	Height int64
+	Round  int64
+	Step   int8
+}
+
+// GreaterThan returns true if the HRSKey is greater than the other HRSKey.
+func (hrs HRSKey) GreaterThan(other HRSKey) bool {
+	if hrs.Height > other.Height {
+		return true
+	}
+	if hrs.Height < other.Height {
+		return false
+	}
+	if hrs.Round > other.Round {
+		return true
+	}
+	if hrs.Round < other.Round {
+		return false
+	}
+	return hrs.Step > other.Step
+}
+
+// LessThan returns true if the HRSKey is less than the other HRSKey.
+func (hrs HRSKey) LessThan(other HRSKey) bool {
+	if hrs.Height < other.Height {
+		return true
+	}
+	if hrs.Height > other.Height {
+		return false
+	}
+	if hrs.Round < other.Round {
+		return true
+	}
+	if hrs.Round > other.Round {
+		return false
+	}
+	return hrs.Step < other.Step
+}
+
+// HRSTKey represents the HRS metadata key with a timestamp.
+type HRSTKey struct {
+	Height    int64
+	Round     int64
+	Step      int8
+	Timestamp int64
+}
+
+// HRSKey returns the HRSKey portion of the HRSTKey.
+func (hrst HRSTKey) HRSKey() HRSKey {
+	return HRSKey{
+		Height: hrst.Height,
+		Round:  hrst.Round,
+		Step:   hrst.Step,
+	}
+}
+
+// HRSTKeyFromProto returns a HRSTKey from a proto.HRST.
+func HRSTKeyFromProto(hrs *proto.HRST) HRSTKey {
+	return HRSTKey{
+		Height:    hrs.GetHeight(),
+		Round:     hrs.GetRound(),
+		Step:      int8(hrs.GetStep()),
+		Timestamp: hrs.GetTimestamp(),
+	}
+}
+
+func (hrst HRSTKey) toProto() *proto.HRST {
+	return &proto.HRST{
+		Height:    hrst.Height,
+		Round:     hrst.Round,
+		Step:      int32(hrst.Step),
+		Timestamp: hrst.Timestamp,
+	}
+}

--- a/signer/local_cosigner.go
+++ b/signer/local_cosigner.go
@@ -45,36 +45,6 @@ type ChainState struct {
 	hrsMeta map[HRSTKey]HrsMetadata
 }
 
-// return true if we are less than the other key
-func (hrst *HRSTKey) Less(other HRSTKey) bool {
-	if hrst.Height < other.Height {
-		return true
-	}
-
-	if hrst.Height > other.Height {
-		return false
-	}
-
-	// height is equal, check round
-
-	if hrst.Round < other.Round {
-		return true
-	}
-
-	if hrst.Round > other.Round {
-		return false
-	}
-
-	// round is equal, check step
-
-	if hrst.Step < other.Step {
-		return true
-	}
-
-	// HRS is greater or equal
-	return false
-}
-
 type CosignerRSAPubKey struct {
 	ID        int
 	PublicKey rsa.PublicKey
@@ -308,7 +278,7 @@ func (cosigner *LocalCosigner) sign(req CosignerSignRequest) (CosignerSignRespon
 	for existingKey := range ccs.hrsMeta {
 		// delete any HRS lower than our signed level
 		// we will not be providing parts for any lower HRS
-		if existingKey.Less(hrst) {
+		if existingKey.HRSKey().LessThan(hrst.HRSKey()) {
 			delete(ccs.hrsMeta, existingKey)
 		}
 	}

--- a/signer/sign_state.go
+++ b/signer/sign_state.go
@@ -51,17 +51,19 @@ func ProposalToStep(_ *cometproto.Proposal) int8 {
 
 // SignState stores signing information for high level watermark management.
 type SignState struct {
-	Height      int64                         `json:"height"`
-	Round       int64                         `json:"round"`
-	Step        int8                          `json:"step"`
-	NoncePublic []byte                        `json:"nonce_public"`
-	Signature   []byte                        `json:"signature,omitempty"`
-	SignBytes   cometbytes.HexBytes           `json:"signbytes,omitempty"`
-	cache       map[HRSKey]SignStateConsensus `json:"-"`
-	mu          sync.RWMutex                  `json:"-"`
-	cond        *sync.Cond                    `json:"-"`
+	Height      int64               `json:"height"`
+	Round       int64               `json:"round"`
+	Step        int8                `json:"step"`
+	NoncePublic []byte              `json:"nonce_public"`
+	Signature   []byte              `json:"signature,omitempty"`
+	SignBytes   cometbytes.HexBytes `json:"signbytes,omitempty"`
 
-	filePath string `json:"-"`
+	filePath string
+
+	// mu protects the cache and is used for signaling with cond.
+	mu    sync.RWMutex
+	cache map[HRSKey]SignStateConsensus
+	cond  *sync.Cond
 }
 
 func (signState *SignState) existingSignatureOrErrorIfRegression(hrst HRSTKey, signBytes []byte) ([]byte, error) {

--- a/signer/sign_state.go
+++ b/signer/sign_state.go
@@ -21,7 +21,6 @@ const (
 	stepPrevote   int8 = 2
 	stepPrecommit int8 = 3
 	blocksToCache      = 3
-	dontSave           = "DONT_SAVE"
 )
 
 func CanonicalVoteToStep(vote *cometproto.CanonicalVote) int8 {
@@ -229,7 +228,7 @@ func (signState *SignState) Save(
 // Save persists the FilePvLastSignState to its filePath.
 func (signState *SignState) save(jsonBytes []byte) {
 	outFile := signState.filePath
-	if outFile == dontSave {
+	if outFile == os.DevNull {
 		return
 	}
 	if outFile == "" {

--- a/signer/sign_state.go
+++ b/signer/sign_state.go
@@ -21,6 +21,7 @@ const (
 	stepPrevote   int8 = 2
 	stepPrecommit int8 = 3
 	blocksToCache      = 3
+	dontSave           = "DONT_SAVE"
 )
 
 func CanonicalVoteToStep(vote *cometproto.CanonicalVote) int8 {
@@ -228,6 +229,9 @@ func (signState *SignState) Save(
 // Save persists the FilePvLastSignState to its filePath.
 func (signState *SignState) save(jsonBytes []byte) {
 	outFile := signState.filePath
+	if outFile == dontSave {
+		return
+	}
 	if outFile == "" {
 		panic("cannot save SignState: filePath not set")
 	}

--- a/signer/threshold_signer_soft.go
+++ b/signer/threshold_signer_soft.go
@@ -153,7 +153,7 @@ func (softSigner *ThresholdSignerSoft) Sign(
 	for existingKey := range softSigner.hrsMeta {
 		// delete any HRS lower than our signed level
 		// we will not be providing parts for any lower HRS
-		if existingKey.Less(hrst) {
+		if existingKey.HRSKey().LessThan(hrst.HRSKey()) {
 			delete(softSigner.hrsMeta, existingKey)
 		}
 	}

--- a/signer/threshold_validator.go
+++ b/signer/threshold_validator.go
@@ -464,9 +464,12 @@ func (pv *ThresholdValidator) LoadSignStateIfNecessary(chainID string) error {
 		return err
 	}
 
+	lastSignStateInitiated := signState.FreshCache()
+	lastSignStateInitiated.filePath = dontSave
+
 	pv.chainState.Store(chainID, ChainSignState{
 		lastSignState:          signState,
-		lastSignStateInitiated: signState.FreshCache(),
+		lastSignStateInitiated: lastSignStateInitiated,
 
 		lastSignStateMutex:          &sync.Mutex{},
 		lastSignStateInitiatedMutex: &sync.Mutex{},


### PR DESCRIPTION
Use sync.Cond for sign state signaling

If a block sign process has been initiated, other sign requests for the same height will wait until that process has completed, and need to be notified that they can proceed to check the caches for the existing signature.

Previously, this was done with a 10ms wait loop. `sync.Cond` gives us a way to notify all of the waiting goroutines.