### PR TITLE
fix raft store npe

### DIFF
--- a/signer/raft_store.go
+++ b/signer/raft_store.go
@@ -281,10 +281,16 @@ func (s *RaftStore) Join(nodeID, addr string) error {
 }
 
 func (s *RaftStore) IsLeader() bool {
+	if s == nil || s.raft == nil {
+		return false
+	}
 	return s.raft.State() == raft.Leader
 }
 
 func (s *RaftStore) GetLeader() raft.ServerAddress {
+	if s == nil || s.raft == nil {
+		return ""
+	}
 	return s.raft.Leader()
 }
 


### PR DESCRIPTION
on startup this can occur if a block sign request comes in before initialization is complete