### PR TITLE
Update migrating.md

### DIFF
--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -52,10 +52,9 @@ The binary should also be installed on your local machine for working with the c
 
 Run the following on your local machine. If you are using the binary on the cosigners rather than container image, run this on each cosigner node VM also.
 ```bash
-TAG=v3.0.0
-$ wget https://github.com/strangelove-ventures/horcrux/releases/download/${TAG}/horcrux_${TAG}_linux_amd64.tar.gz
-$ tar -xzf horcrux_${TAG}_linux_amd64.tar.gz
-$ sudo mv horcrux /usr/bin/horcrux && rm horcrux_${TAG}_linux_amd64.tar.gz README.md LICENSE.md
+TAG=v3.1.0
+$ wget https://github.com/strangelove-ventures/horcrux/releases/download/${TAG}/horcrux_linux-amd64
+$ sudo mv horcrux_linux-amd64 /usr/bin/horcrux
 ```
 
 For each cosigner node (not required on local machine): once the binary is installed in `/usr/bin`, install the `systemd` unit file. You can find an [example here](./horcrux.service):


### PR DESCRIPTION
TAG version changed to latest binary
wget changed address to new download address for binary no need to extract file since binary is downloaded directly no need to delete files that would have been in packages since they are no longer there