### PR TITLE
FEAT: Add per chain and node metrics

### DIFF
--- a/signer/metrics.go
+++ b/signer/metrics.go
@@ -171,28 +171,32 @@ var (
 			"(Should not increase beyond block time; If high, may indicate raft joining issue for CoSigner) ",
 	})
 
-	missedPrecommits = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "signer_missed_precommits",
-		Help: "Consecutive Precommit Missed",
-	},
+	missedPrecommits = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "signer_missed_precommits",
+			Help: "Consecutive Precommit Missed",
+		},
 		[]string{"chain_id", "node"},
 	)
-	missedPrevotes = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "signer_missed_prevotes",
-		Help: "Consecutive Prevote Missed",
-	},
+	missedPrevotes = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "signer_missed_prevotes",
+			Help: "Consecutive Prevote Missed",
+		},
 		[]string{"chain_id", "node"},
 	)
-	totalMissedPrecommits = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "signer_total_missed_precommits",
-		Help: "Total Precommit Missed",
-	},
+	totalMissedPrecommits = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "signer_total_missed_precommits",
+			Help: "Total Precommit Missed",
+		},
 		[]string{"chain_id", "node"},
 	)
-	totalMissedPrevotes = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "signer_total_missed_prevotes",
-		Help: "Total Prevote Missed",
-	},
+	totalMissedPrevotes = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "signer_total_missed_prevotes",
+			Help: "Total Prevote Missed",
+		},
 		[]string{"chain_id", "node"},
 	)
 
@@ -211,29 +215,33 @@ var (
 		[]string{"peerid"},
 	)
 
-	sentryConnectTries = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "signer_sentry_connect_tries",
-		Help: "Consecutive Number of times sentry TCP connect has been tried (High count may indicate validator restarts)",
-	},
+	sentryConnectTries = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "signer_sentry_connect_tries",
+			Help: "Consecutive Number of times sentry TCP connect has been tried (High count may indicate validator restarts)",
+		},
 		[]string{"node"},
 	)
-	totalSentryConnectTries = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "signer_total_sentry_connect_tries",
-		Help: "Total Number of times sentry TCP connect has been tried (High count may indicate validator restarts)",
-	},
+	totalSentryConnectTries = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "signer_total_sentry_connect_tries",
+			Help: "Total Number of times sentry TCP connect has been tried (High count may indicate validator restarts)",
+		},
 		[]string{"node"},
 	)
 
-	beyondBlockErrors = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "signer_total_beyond_block_errors",
-		Help: "Total Times Signing Started but duplicate height/round request arrives",
-	},
+	beyondBlockErrors = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "signer_total_beyond_block_errors",
+			Help: "Total Times Signing Started but duplicate height/round request arrives",
+		},
 		[]string{"chain_id", "node"},
 	)
-	failedSignVote = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "signer_total_failed_sign_vote",
-		Help: "Total Times Signer Failed to sign block - Unstarted and Unexepcted Height",
-	},
+	failedSignVote = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "signer_total_failed_sign_vote",
+			Help: "Total Times Signer Failed to sign block - Unstarted and Unexepcted Height",
+		},
 		[]string{"chain_id", "node"},
 	)
 

--- a/signer/metrics.go
+++ b/signer/metrics.go
@@ -74,48 +74,79 @@ var (
 	metricsTimeKeeper       = newMetricsTimer()
 
 	// Prometheus Metrics
-	totalPubKeyRequests = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "signer_total_pubkey_requests",
-		Help: "Total times public key requested (High count may indicate validator restarts)",
-	})
-	lastPrecommitHeight = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "signer_last_precommit_height",
-		Help: "Last Height Precommit Signed",
-	})
-	lastPrevoteHeight = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "signer_last_prevote_height",
-		Help: "Last Height Prevote Signed",
-	})
+	totalPubKeyRequests = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "signer_total_pubkey_requests",
+			Help: "Total times public key requested (High count may indicate validator restarts)",
+		},
+		[]string{"chain_id", "node"},
+	)
+	lastPrecommitHeight = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "signer_last_precommit_height",
+			Help: "Last Height Precommit Signed",
+		},
+		[]string{"chain_id", "node"},
+	)
 
-	lastProposalHeight = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "signer_last_proposal_height",
-		Help: "Last Height Proposal Signed",
-	})
-	lastPrecommitRound = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "signer_last_precommit_round",
-		Help: "Last Round Precommit Signed",
-	})
-	lastPrevoteRound = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "signer_last_prevote_round",
-		Help: "Last Round Prevote Signed",
-	})
-	lastProposalRound = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "signer_last_proposal_round",
-		Help: "Last Round Proposal Signed",
-	})
+	lastPrevoteHeight = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "signer_last_prevote_height",
+			Help: "Last Height Prevote Signed",
+		},
+		[]string{"chain_id", "node"},
+	)
 
-	totalPrecommitsSigned = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "signer_total_precommits_signed",
-		Help: "Total Precommit Signed",
-	})
-	totalPrevotesSigned = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "signer_total_prevotes_signed",
-		Help: "Total Prevote Signed",
-	})
-	totalProposalsSigned = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "signer_total_proposals_signed",
-		Help: "Total Proposal Signed",
-	})
+	lastProposalHeight = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "signer_last_proposal_height",
+			Help: "Last Height Proposal Signed",
+		},
+		[]string{"chain_id", "node"},
+	)
+	lastPrecommitRound = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "signer_last_precommit_round",
+			Help: "Last Round Precommit Signed",
+		},
+		[]string{"chain_id", "node"},
+	)
+	lastPrevoteRound = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "signer_last_prevote_round",
+			Help: "Last Round Prevote Signed",
+		},
+		[]string{"chain_id", "node"},
+	)
+	lastProposalRound = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "signer_last_proposal_round",
+			Help: "Last Round Proposal Signed",
+		},
+		[]string{"chain_id", "node"},
+	)
+
+	totalPrecommitsSigned = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "signer_total_precommits_signed",
+			Help: "Total Precommit Signed",
+		},
+		[]string{"chain_id", "node"},
+	)
+	totalPrevotesSigned = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "signer_total_prevotes_signed",
+			Help: "Total Prevote Signed",
+		},
+		[]string{"chain_id", "node"},
+	)
+	totalProposalsSigned = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "signer_total_proposals_signed",
+			Help: "Total Proposal Signed",
+		},
+		[]string{"chain_id", "node"},
+	)
 
 	secondsSinceLastPrecommit = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "signer_seconds_since_last_precommit",
@@ -140,22 +171,30 @@ var (
 			"(Should not increase beyond block time; If high, may indicate raft joining issue for CoSigner) ",
 	})
 
-	missedPrecommits = promauto.NewGauge(prometheus.GaugeOpts{
+	missedPrecommits = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "signer_missed_precommits",
 		Help: "Consecutive Precommit Missed",
-	})
-	missedPrevotes = promauto.NewGauge(prometheus.GaugeOpts{
+	},
+		[]string{"chain_id", "node"},
+	)
+	missedPrevotes = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "signer_missed_prevotes",
 		Help: "Consecutive Prevote Missed",
-	})
-	totalMissedPrecommits = promauto.NewCounter(prometheus.CounterOpts{
+	},
+		[]string{"chain_id", "node"},
+	)
+	totalMissedPrecommits = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "signer_total_missed_precommits",
 		Help: "Total Precommit Missed",
-	})
-	totalMissedPrevotes = promauto.NewCounter(prometheus.CounterOpts{
+	},
+		[]string{"chain_id", "node"},
+	)
+	totalMissedPrevotes = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "signer_total_missed_prevotes",
 		Help: "Total Prevote Missed",
-	})
+	},
+		[]string{"chain_id", "node"},
+	)
 
 	missedNonces = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -172,23 +211,31 @@ var (
 		[]string{"peerid"},
 	)
 
-	sentryConnectTries = promauto.NewGauge(prometheus.GaugeOpts{
+	sentryConnectTries = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "signer_sentry_connect_tries",
 		Help: "Consecutive Number of times sentry TCP connect has been tried (High count may indicate validator restarts)",
-	})
-	totalSentryConnectTries = promauto.NewCounter(prometheus.CounterOpts{
+	},
+		[]string{"node"},
+	)
+	totalSentryConnectTries = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "signer_total_sentry_connect_tries",
 		Help: "Total Number of times sentry TCP connect has been tried (High count may indicate validator restarts)",
-	})
+	},
+		[]string{"node"},
+	)
 
-	beyondBlockErrors = promauto.NewCounter(prometheus.CounterOpts{
+	beyondBlockErrors = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "signer_total_beyond_block_errors",
 		Help: "Total Times Signing Started but duplicate height/round request arrives",
-	})
-	failedSignVote = promauto.NewCounter(prometheus.CounterOpts{
+	},
+		[]string{"chain_id", "node"},
+	)
+	failedSignVote = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "signer_total_failed_sign_vote",
 		Help: "Total Times Signer Failed to sign block - Unstarted and Unexepcted Height",
-	})
+	},
+		[]string{"chain_id", "node"},
+	)
 
 	totalRaftLeader = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "signer_total_raft_leader",


### PR DESCRIPTION
## Summary
This Pull Request introduces per-chain and per-node metrics collection into the Horcrux monitoring system. The main objective of this update is to enhance system observability, enabling a deeper insight into the individual performance of each node and chain. This is instrumental for network health assessment, debugging, and performance optimization.

## Background
Prior to this PR, Horcrux only provided global metrics which made it challenging to debug issues on a per-node or per-chain basis. As Horcrux networks can be composed of multiple chains and nodes, a granular level of metrics is essential for operational excellence.

## Changes
- New Labels collection in the metrics that might pertain to multiple chains and/or signer (sentry) nodes

---

As this is an extension of the existing metrics collection, it does not require special migration steps. However, due to the label changes, ensure compatibility with dependent services and tests.