### PR TITLE
fix error checking over rpc

### DIFF
--- a/signer/sign_state.go
+++ b/signer/sign_state.go
@@ -348,7 +348,7 @@ func newStepRegressionError(height, round int64, regressed, last int8) *StepRegr
 	}
 }
 
-var EmptySignBytesError = errors.New("no SignBytes found")
+var ErrEmptySignBytes = errors.New("no SignBytes found")
 
 // CheckHRS checks the given height, round, step (HRS) against that of the
 // SignState. It returns an error if the arguments constitute a regression,
@@ -376,7 +376,7 @@ func (signState *SignState) CheckHRS(hrst HRSTKey) (bool, error) {
 					}
 					return true, nil
 				}
-				return false, EmptySignBytesError
+				return false, ErrEmptySignBytes
 			}
 		}
 	}

--- a/signer/sign_state.go
+++ b/signer/sign_state.go
@@ -348,11 +348,7 @@ func newStepRegressionError(height, round int64, regressed, last int8) *StepRegr
 	}
 }
 
-type EmptySignBytesError struct{}
-
-func (e *EmptySignBytesError) Error() string {
-	return "no SignBytes found"
-}
+var EmptySignBytesError = errors.New("no SignBytes found")
 
 // CheckHRS checks the given height, round, step (HRS) against that of the
 // SignState. It returns an error if the arguments constitute a regression,
@@ -380,7 +376,7 @@ func (signState *SignState) CheckHRS(hrst HRSTKey) (bool, error) {
 					}
 					return true, nil
 				}
-				return false, new(EmptySignBytesError)
+				return false, EmptySignBytesError
 			}
 		}
 	}

--- a/signer/threshold_validator.go
+++ b/signer/threshold_validator.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -732,23 +733,13 @@ func (pv *ThresholdValidator) Sign(ctx context.Context, chainID string, block Bl
 						return err
 					}
 
-					hre := new(HeightRegressionError)
-					rre := new(RoundRegressionError)
-					sre := new(StepRegressionError)
-					ese := new(EmptySignBytesError)
-					ase := new(AlreadySignedVoteError)
-					dbe := new(DiffBlockIDsError)
-					cde := new(ConflictingDataError)
-					ue := new(UnmarshalError)
-
-					if !errors.As(err, &hre) &&
-						!errors.As(err, &rre) &&
-						!errors.As(err, &sre) &&
-						!errors.As(err, &ese) &&
-						!errors.As(err, &ue) &&
-						!errors.As(err, &ase) &&
-						!errors.As(err, &dbe) &&
-						!errors.As(err, &cde) {
+					// TODO how can we determine error type when it's wrapped in an RPCError?
+					if !strings.Contains(err.Error(), "regression") &&
+						!strings.Contains(err.Error(), EmptySignBytesError.Error()) &&
+						!strings.Contains(err.Error(), "refusing to sign") &&
+						!strings.Contains(err.Error(), "differing block IDs") &&
+						!strings.Contains(err.Error(), "conflicting data") &&
+						!strings.Contains(err.Error(), "cannot be unmarshalled into") {
 						pv.cosignerHealth.MarkUnhealthy(cosigner)
 						pv.nonceCache.ClearNonces(cosigner)
 					}


### PR DESCRIPTION
The error detection with `errors.As` does not work for the RemoteCosigner since the error type is lost over grpc.

The purpose of this error check is to determine if there is a network error indicating the remote cosigner is down and the nonce cache should be invalidated for them. This can be replaced with a grpc status.Code check, where we only invalidate the cache on grpc errors that indicate an outage of the remote cosigner.

Improves a few logs