### PR TITLE
Fix - running out of nonces under load

### DIFF
--- a/signer/cosigner_nonce_cache.go
+++ b/signer/cosigner_nonce_cache.go
@@ -163,12 +163,6 @@ func (cnc *CosignerNonceCache) reconcile(ctx context.Context) {
 	if noncesPerMin < 0 {
 		noncesPerMin = 0
 	}
-	cnc.logger.Debug("Reconciling nonces",
-		"remaining", remainingNonces,
-		"lastReconcileNonces", lastReconcileNonces,
-		"noncesPerMin", noncesPerMin,
-		"timeSinceLastReconcile", timeSinceLastReconcile,
-	)
 
 	if cnc.noncesPerMinute == 0 {
 		// initialize nonces per minute for weighted average

--- a/signer/cosigner_nonce_cache.go
+++ b/signer/cosigner_nonce_cache.go
@@ -96,8 +96,6 @@ func (nc *NonceCache) Set(uuid uuid.UUID, cn *CachedNonce) {
 }
 
 func (nc *NonceCache) GetSortedByExpiration() []*CachedNonce {
-	nc.mu.RLock()
-	defer nc.mu.RUnlock()
 	cns := make([]*CachedNonce, 0, len(nc.cache))
 	for _, cn := range nc.cache {
 		cns = append(cns, cn)

--- a/signer/cosigner_nonce_cache_test.go
+++ b/signer/cosigner_nonce_cache_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNonceCache(t *testing.T) {
+func TestNonceCache(_ *testing.T) {
 	nc := NonceCache{}
 	for i := 0; i < 10; i++ {
 		nc.Add(&CachedNonce{UUID: uuid.New(), Expiration: time.Now().Add(1 * time.Second)})
@@ -59,7 +59,7 @@ func TestNonceCacheDemand(t *testing.T) {
 		&MockLeader{id: 1, leader: &ThresholdValidator{myCosigner: lcs[0]}},
 		500*time.Millisecond,
 		100*time.Millisecond,
-		5*time.Second,
+		defaultNonceExpiration,
 		2,
 		mp,
 	)
@@ -119,11 +119,11 @@ func TestNonceCacheExpiration(t *testing.T) {
 
 	go nonceCache.Start(ctx)
 
-	time.Sleep(500 * time.Millisecond)
+	time.Sleep(520 * time.Millisecond)
 
 	nonceCache.LoadN(ctx, 500)
 
-	time.Sleep(500 * time.Millisecond)
+	time.Sleep(520 * time.Millisecond)
 
 	size := nonceCache.cache.Size()
 
@@ -134,7 +134,7 @@ func TestNonceCacheExpiration(t *testing.T) {
 	require.Equal(t, count, 6)
 	require.Equal(t, 500, pruned)
 
-	time.Sleep(500 * time.Millisecond)
+	time.Sleep(520 * time.Millisecond)
 
 	count, pruned = mp.Result()
 

--- a/signer/cosigner_nonce_cache_test.go
+++ b/signer/cosigner_nonce_cache_test.go
@@ -125,10 +125,15 @@ func TestNonceCacheExpiration(t *testing.T) {
 
 	count, pruned := mp.Result()
 
+	// we should have pruned at least three times after
+	// waiting for a second with a reconcile interval of 250ms
 	require.GreaterOrEqual(t, count, 3)
+
+	// we should have pruned at least the number of nonces we loaded and knew would expire
 	require.GreaterOrEqual(t, pruned, loadN)
 
 	cancel()
 
+	// the cache should have at most the trim padding since no nonces are being consumed.
 	require.LessOrEqual(t, nonceCache.cache.Size(), targetTrim)
 }

--- a/signer/cosigner_nonce_cache_test.go
+++ b/signer/cosigner_nonce_cache_test.go
@@ -48,7 +48,7 @@ func TestNonceCacheDemand(t *testing.T) {
 		&MockLeader{id: 1, leader: &ThresholdValidator{myCosigner: lcs[0]}},
 		500*time.Millisecond,
 		100*time.Millisecond,
-		1*time.Second,
+		5*time.Second,
 		2,
 		mp,
 	)

--- a/signer/cosigner_nonce_cache_test.go
+++ b/signer/cosigner_nonce_cache_test.go
@@ -8,8 +8,19 @@ import (
 	"time"
 
 	cometlog "github.com/cometbft/cometbft/libs/log"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
+
+func TestNonceCache(t *testing.T) {
+	nc := NonceCache{}
+	for i := 0; i < 10; i++ {
+		nc.Add(&CachedNonce{UUID: uuid.New(), Expiration: time.Now().Add(1 * time.Second)})
+	}
+
+	nc.Delete(nc.Size() - 1)
+	nc.Delete(0)
+}
 
 type mockPruner struct {
 	cnc    *CosignerNonceCache

--- a/signer/cosigner_nonce_cache_test.go
+++ b/signer/cosigner_nonce_cache_test.go
@@ -10,12 +10,32 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type mockPruner struct {
+	cnc    *CosignerNonceCache
+	count  int
+	pruned int
+}
+
+func (mp *mockPruner) PruneNonces() {
+	mp.cnc.cache.mu.Lock()
+	defer mp.cnc.cache.mu.Unlock()
+	mp.count++
+	for u, cn := range mp.cnc.cache.cache {
+		if time.Now().After(cn.Expiration) {
+			mp.pruned++
+			delete(mp.cnc.cache.cache, u)
+		}
+	}
+}
+
 func TestNonceCacheDemand(t *testing.T) {
 	lcs, _ := getTestLocalCosigners(t, 2, 3)
 	cosigners := make([]Cosigner, len(lcs))
 	for i, lc := range lcs {
 		cosigners[i] = lc
 	}
+
+	mp := &mockPruner{}
 
 	nonceCache := NewCosignerNonceCache(
 		cometlog.NewTMLogger(cometlog.NewSyncWriter(os.Stdout)),
@@ -24,7 +44,10 @@ func TestNonceCacheDemand(t *testing.T) {
 		500*time.Millisecond,
 		100*time.Millisecond,
 		2,
+		mp,
 	)
+
+	mp.cnc = nonceCache
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -45,6 +68,9 @@ func TestNonceCacheDemand(t *testing.T) {
 
 	cancel()
 
-	target := int(nonceCache.noncesPerMinute*.01) + 10
+	target := int(nonceCache.noncesPerMinute*.01) + int(nonceCache.noncesPerMinute/30) + 100
 	require.LessOrEqual(t, size, target)
+
+	require.Greater(t, mp.count, 0)
+	require.Equal(t, 0, mp.pruned)
 }

--- a/signer/threshold_validator.go
+++ b/signer/threshold_validator.go
@@ -84,6 +84,7 @@ func NewThresholdValidator(
 		leader,
 		defaultGetNoncesInterval,
 		defaultGetNoncesTimeout,
+		defaultNonceExpiration,
 		uint8(threshold),
 		nil,
 	)

--- a/signer/threshold_validator.go
+++ b/signer/threshold_validator.go
@@ -85,6 +85,7 @@ func NewThresholdValidator(
 		defaultGetNoncesInterval,
 		defaultGetNoncesTimeout,
 		uint8(threshold),
+		nil,
 	)
 	return &ThresholdValidator{
 		logger:                      logger,


### PR DESCRIPTION
Account for continued nonce consumption in target

Sort by expiration when getting next nonce for signing so that soonest expiring nonces are consumed first.

Also fixed a bug with the same UUID being used for multiple sign operations (and failing for all after first) due to not locking for entire get>delete operation