### PR TITLE
Update Horcrux go.mod module path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ COMMIT  := $(shell git log -1 --format='%H')
 
 all: install
 
-LD_FLAGS = -X github.com/strangelove-ventures/horcrux/cmd/horcrux/cmd.Version=$(VERSION) \
-	-X github.com/strangelove-ventures/horcrux/cmd/horcrux/cmd.Commit=$(COMMIT)
+LD_FLAGS = -X github.com/strangelove-ventures/horcrux/v3/cmd/horcrux/cmd.Version=$(VERSION) \
+	-X github.com/strangelove-ventures/horcrux/v3/cmd/horcrux/cmd.Commit=$(COMMIT)
 
 LD_FLAGS += $(LDFLAGS)
 LD_FLAGS := $(strip $(LD_FLAGS))

--- a/client/address_test.go
+++ b/client/address_test.go
@@ -3,7 +3,7 @@ package client_test
 import (
 	"testing"
 
-	"github.com/strangelove-ventures/horcrux/client"
+	"github.com/strangelove-ventures/horcrux/v3/client"
 	"github.com/stretchr/testify/require"
 )
 

--- a/cmd/horcrux/cmd/address.go
+++ b/cmd/horcrux/cmd/address.go
@@ -10,7 +10,7 @@ import (
 	cometprivval "github.com/cometbft/cometbft/privval"
 	"github.com/cosmos/cosmos-sdk/types/bech32"
 	"github.com/spf13/cobra"
-	"github.com/strangelove-ventures/horcrux/signer"
+	"github.com/strangelove-ventures/horcrux/v3/signer"
 )
 
 type AddressCmdOutput struct {

--- a/cmd/horcrux/cmd/config.go
+++ b/cmd/horcrux/cmd/config.go
@@ -5,7 +5,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/strangelove-ventures/horcrux/signer"
+	"github.com/strangelove-ventures/horcrux/v3/signer"
 )
 
 const (

--- a/cmd/horcrux/cmd/leader_election.go
+++ b/cmd/horcrux/cmd/leader_election.go
@@ -7,10 +7,10 @@ import (
 
 	grpcretry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 	"github.com/spf13/cobra"
-	"github.com/strangelove-ventures/horcrux/client"
-	"github.com/strangelove-ventures/horcrux/signer"
-	"github.com/strangelove-ventures/horcrux/signer/multiresolver"
-	"github.com/strangelove-ventures/horcrux/signer/proto"
+	"github.com/strangelove-ventures/horcrux/v3/client"
+	"github.com/strangelove-ventures/horcrux/v3/signer"
+	"github.com/strangelove-ventures/horcrux/v3/signer/multiresolver"
+	"github.com/strangelove-ventures/horcrux/v3/signer/proto"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )

--- a/cmd/horcrux/cmd/migrate.go
+++ b/cmd/horcrux/cmd/migrate.go
@@ -13,7 +13,7 @@ import (
 	cometcryptoencoding "github.com/cometbft/cometbft/crypto/encoding"
 	cometprotocrypto "github.com/cometbft/cometbft/proto/tendermint/crypto"
 	"github.com/spf13/cobra"
-	"github.com/strangelove-ventures/horcrux/signer"
+	"github.com/strangelove-ventures/horcrux/v3/signer"
 	amino "github.com/tendermint/go-amino"
 	"gopkg.in/yaml.v2"
 )

--- a/cmd/horcrux/cmd/migrate_test.go
+++ b/cmd/horcrux/cmd/migrate_test.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/strangelove-ventures/horcrux/cmd/horcrux/cmd/testdata"
+	"github.com/strangelove-ventures/horcrux/v3/cmd/horcrux/cmd/testdata"
 	"github.com/stretchr/testify/require"
 )
 

--- a/cmd/horcrux/cmd/root.go
+++ b/cmd/horcrux/cmd/root.go
@@ -8,7 +8,7 @@ import (
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/strangelove-ventures/horcrux/signer"
+	"github.com/strangelove-ventures/horcrux/v3/signer"
 	"gopkg.in/yaml.v2"
 )
 

--- a/cmd/horcrux/cmd/shards.go
+++ b/cmd/horcrux/cmd/shards.go
@@ -21,7 +21,7 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/cobra"
-	"github.com/strangelove-ventures/horcrux/signer"
+	"github.com/strangelove-ventures/horcrux/v3/signer"
 )
 
 func createCosignerDirectoryIfNecessary(out string, id int) (string, error) {

--- a/cmd/horcrux/cmd/single_signer.go
+++ b/cmd/horcrux/cmd/single_signer.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/strangelove-ventures/horcrux/signer"
+	"github.com/strangelove-ventures/horcrux/v3/signer"
 )
 
 const (

--- a/cmd/horcrux/cmd/start.go
+++ b/cmd/horcrux/cmd/start.go
@@ -7,7 +7,7 @@ import (
 	cometlog "github.com/cometbft/cometbft/libs/log"
 	"github.com/cometbft/cometbft/libs/service"
 	"github.com/spf13/cobra"
-	"github.com/strangelove-ventures/horcrux/signer"
+	"github.com/strangelove-ventures/horcrux/v3/signer"
 )
 
 func startCmd() *cobra.Command {

--- a/cmd/horcrux/cmd/state.go
+++ b/cmd/horcrux/cmd/state.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/strangelove-ventures/horcrux/signer"
+	"github.com/strangelove-ventures/horcrux/v3/signer"
 
 	cometjson "github.com/cometbft/cometbft/libs/json"
 	cometlog "github.com/cometbft/cometbft/libs/log"

--- a/cmd/horcrux/cmd/state_test.go
+++ b/cmd/horcrux/cmd/state_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/strangelove-ventures/horcrux/signer"
+	"github.com/strangelove-ventures/horcrux/v3/signer"
 	"github.com/stretchr/testify/require"
 )
 

--- a/cmd/horcrux/cmd/threshold.go
+++ b/cmd/horcrux/cmd/threshold.go
@@ -9,7 +9,7 @@ import (
 
 	cometlog "github.com/cometbft/cometbft/libs/log"
 	cometservice "github.com/cometbft/cometbft/libs/service"
-	"github.com/strangelove-ventures/horcrux/signer"
+	"github.com/strangelove-ventures/horcrux/v3/signer"
 )
 
 const maxWaitForSameBlockAttempts = 3

--- a/cmd/horcrux/main.go
+++ b/cmd/horcrux/main.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 package main
 
-import "github.com/strangelove-ventures/horcrux/cmd/horcrux/cmd"
+import "github.com/strangelove-ventures/horcrux/v3/cmd/horcrux/cmd"
 
 func main() {
 	cmd.Execute()

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/strangelove-ventures/horcrux
+module github.com/strangelove-ventures/horcrux/v3
 
 go 1.21
 

--- a/proto/strangelove/horcrux/cosigner.proto
+++ b/proto/strangelove/horcrux/cosigner.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 package strangelove.horcrux;
 
-option go_package = "github.com/strangelove-ventures/horcrux/signer/proto";
+option go_package = "github.com/strangelove-ventures/horcrux/v3/signer/proto";
 
 service Cosigner {
 	rpc SignBlock (SignBlockRequest) returns (SignBlockResponse) {}

--- a/proto/strangelove/horcrux/remote_signer.proto
+++ b/proto/strangelove/horcrux/remote_signer.proto
@@ -3,7 +3,7 @@ package strangelove.horcrux;
 
 import "strangelove/horcrux/cosigner.proto";
 
-option go_package = "github.com/strangelove-ventures/horcrux/signer/proto";
+option go_package = "github.com/strangelove-ventures/horcrux/v3/signer/proto";
 
 service RemoteSigner {
 	rpc PubKey (PubKeyRequest) returns (PubKeyResponse) {}

--- a/signer/cond/cond_test.go
+++ b/signer/cond/cond_test.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/strangelove-ventures/horcrux/signer/cond"
+	"github.com/strangelove-ventures/horcrux/v3/signer/cond"
 	"github.com/stretchr/testify/require"
 )
 

--- a/signer/config.go
+++ b/signer/config.go
@@ -16,7 +16,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	"github.com/cosmos/cosmos-sdk/types/bech32"
-	"github.com/strangelove-ventures/horcrux/client"
+	"github.com/strangelove-ventures/horcrux/v3/client"
 	"gopkg.in/yaml.v2"
 )
 

--- a/signer/config_test.go
+++ b/signer/config_test.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/strangelove-ventures/horcrux/signer"
+	"github.com/strangelove-ventures/horcrux/v3/signer"
 	"github.com/stretchr/testify/require"
 )
 

--- a/signer/cosigner.go
+++ b/signer/cosigner.go
@@ -6,7 +6,7 @@ import (
 
 	cometcrypto "github.com/cometbft/cometbft/crypto"
 	"github.com/google/uuid"
-	"github.com/strangelove-ventures/horcrux/signer/proto"
+	"github.com/strangelove-ventures/horcrux/v3/signer/proto"
 )
 
 // Cosigner interface is a set of methods for an m-of-n threshold signature.

--- a/signer/cosigner_grpc_server.go
+++ b/signer/cosigner_grpc_server.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/raft"
-	"github.com/strangelove-ventures/horcrux/signer/proto"
+	"github.com/strangelove-ventures/horcrux/v3/signer/proto"
 )
 
 var _ proto.CosignerServer = &CosignerGRPCServer{}

--- a/signer/cosigner_health.go
+++ b/signer/cosigner_health.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	cometlog "github.com/cometbft/cometbft/libs/log"
-	"github.com/strangelove-ventures/horcrux/signer/proto"
+	"github.com/strangelove-ventures/horcrux/v3/signer/proto"
 )
 
 const (

--- a/signer/hrs.go
+++ b/signer/hrs.go
@@ -1,7 +1,7 @@
 package signer
 
 import (
-	"github.com/strangelove-ventures/horcrux/signer/proto"
+	"github.com/strangelove-ventures/horcrux/v3/signer/proto"
 )
 
 // HRSKey represents the key for the HRS metadata map.

--- a/signer/multiresolver/multi_test.go
+++ b/signer/multiresolver/multi_test.go
@@ -10,9 +10,9 @@ import (
 	"time"
 
 	grpcretry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
-	"github.com/strangelove-ventures/horcrux/signer"
-	"github.com/strangelove-ventures/horcrux/signer/multiresolver"
-	"github.com/strangelove-ventures/horcrux/signer/proto"
+	"github.com/strangelove-ventures/horcrux/v3/signer"
+	"github.com/strangelove-ventures/horcrux/v3/signer/multiresolver"
+	"github.com/strangelove-ventures/horcrux/v3/signer/proto"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"

--- a/signer/raft_store.go
+++ b/signer/raft_store.go
@@ -26,7 +26,7 @@ import (
 	"github.com/cometbft/cometbft/libs/service"
 	"github.com/hashicorp/raft"
 	boltdb "github.com/hashicorp/raft-boltdb/v2"
-	"github.com/strangelove-ventures/horcrux/signer/proto"
+	"github.com/strangelove-ventures/horcrux/v3/signer/proto"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/reflection"

--- a/signer/remote_cosigner.go
+++ b/signer/remote_cosigner.go
@@ -8,7 +8,7 @@ import (
 
 	cometcrypto "github.com/cometbft/cometbft/crypto"
 	"github.com/google/uuid"
-	"github.com/strangelove-ventures/horcrux/signer/proto"
+	"github.com/strangelove-ventures/horcrux/v3/signer/proto"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )

--- a/signer/remote_signer_grpc_server.go
+++ b/signer/remote_signer_grpc_server.go
@@ -8,7 +8,7 @@ import (
 	cometlog "github.com/cometbft/cometbft/libs/log"
 	cometservice "github.com/cometbft/cometbft/libs/service"
 
-	"github.com/strangelove-ventures/horcrux/signer/proto"
+	"github.com/strangelove-ventures/horcrux/v3/signer/proto"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
 )

--- a/signer/services_test.go
+++ b/signer/services_test.go
@@ -14,7 +14,7 @@ import (
 
 	cometlog "github.com/cometbft/cometbft/libs/log"
 	cometservice "github.com/cometbft/cometbft/libs/service"
-	"github.com/strangelove-ventures/horcrux/signer"
+	"github.com/strangelove-ventures/horcrux/v3/signer"
 
 	fork "github.com/kraken-hpc/go-fork"
 	"github.com/stretchr/testify/require"

--- a/signer/sign_state.go
+++ b/signer/sign_state.go
@@ -15,7 +15,7 @@ import (
 	cometproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	comet "github.com/cometbft/cometbft/types"
 	"github.com/gogo/protobuf/proto"
-	"github.com/strangelove-ventures/horcrux/signer/cond"
+	"github.com/strangelove-ventures/horcrux/v3/signer/cond"
 )
 
 const (

--- a/signer/threshold_validator.go
+++ b/signer/threshold_validator.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cometbft/cometbft/libs/log"
 	cometrpcjsontypes "github.com/cometbft/cometbft/rpc/jsonrpc/types"
 	"github.com/google/uuid"
-	"github.com/strangelove-ventures/horcrux/signer/proto"
+	"github.com/strangelove-ventures/horcrux/v3/signer/proto"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"

--- a/test/horcrux_test.go
+++ b/test/horcrux_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/cometbft/cometbft/crypto"
 	dockertypes "github.com/docker/docker/api/types"
-	"github.com/strangelove-ventures/horcrux/signer"
+	"github.com/strangelove-ventures/horcrux/v3/signer"
 	interchaintest "github.com/strangelove-ventures/interchaintest/v8"
 	"github.com/strangelove-ventures/interchaintest/v8/chain/cosmos"
 	"github.com/strangelove-ventures/interchaintest/v8/ibc"

--- a/test/validator.go
+++ b/test/validator.go
@@ -14,7 +14,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/bech32"
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	"github.com/docker/docker/client"
-	"github.com/strangelove-ventures/horcrux/signer/proto"
+	"github.com/strangelove-ventures/horcrux/v3/signer/proto"
 	interchaintest "github.com/strangelove-ventures/interchaintest/v8"
 	"github.com/strangelove-ventures/interchaintest/v8/chain/cosmos"
 	"github.com/strangelove-ventures/interchaintest/v8/ibc"

--- a/test/validator_single.go
+++ b/test/validator_single.go
@@ -10,7 +10,7 @@ import (
 	cometjson "github.com/cometbft/cometbft/libs/json"
 	"github.com/cometbft/cometbft/privval"
 	"github.com/docker/docker/client"
-	"github.com/strangelove-ventures/horcrux/signer"
+	"github.com/strangelove-ventures/horcrux/v3/signer"
 	interchaintest "github.com/strangelove-ventures/interchaintest/v8"
 	"github.com/strangelove-ventures/interchaintest/v8/chain/cosmos"
 	"github.com/strangelove-ventures/interchaintest/v8/ibc"

--- a/test/validator_threshold.go
+++ b/test/validator_threshold.go
@@ -12,7 +12,7 @@ import (
 	"github.com/docker/docker/client"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
-	"github.com/strangelove-ventures/horcrux/signer"
+	"github.com/strangelove-ventures/horcrux/v3/signer"
 	interchaintest "github.com/strangelove-ventures/interchaintest/v8"
 	"github.com/strangelove-ventures/interchaintest/v8/chain/cosmos"
 	"github.com/strangelove-ventures/interchaintest/v8/ibc"


### PR DESCRIPTION
Horcrux is currently at major version 3.X
From golang perspective module path should be updated to contain `v3` in path, ref: https://go.dev/doc/modules/version-numbers#major 

> A major version update to a number higher than v1 will also have a new module path. That’s because the module path will have the major version number appended, as in the following example:
>module example.com/mymodule/v2 v2.0.0