### PR TITLE
fix(runtime): debug server not starting due to blocking grpc serve

### DIFF
--- a/signer/remote_signer_grpc_server.go
+++ b/signer/remote_signer_grpc_server.go
@@ -57,7 +57,7 @@ func (s *RemoteSignerGRPCServer) OnStart() error {
 
 func (s *RemoteSignerGRPCServer) serve(sock net.Listener) {
 	if err := s.server.Serve(sock); err != nil {
-		panic(fmt.Errorf("failed to start remote signer grpc server: %w", err))
+		panic(fmt.Errorf("remote signer grpc server: %w", err))
 	}
 }
 

--- a/signer/remote_signer_grpc_server.go
+++ b/signer/remote_signer_grpc_server.go
@@ -2,6 +2,7 @@ package signer
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"time"
 
@@ -50,7 +51,14 @@ func (s *RemoteSignerGRPCServer) OnStart() error {
 	s.server = grpc.NewServer()
 	proto.RegisterRemoteSignerServer(s.server, s)
 	reflection.Register(s.server)
-	return s.server.Serve(sock)
+	go s.serve(sock)
+	return nil
+}
+
+func (s *RemoteSignerGRPCServer) serve(sock net.Listener) {
+	if err := s.server.Serve(sock); err != nil {
+		panic(fmt.Errorf("failed to start remote signer grpc server: %w", err))
+	}
 }
 
 func (s *RemoteSignerGRPCServer) OnStop() {


### PR DESCRIPTION
The debug server was not starting when `grpcAddr` was enabled due to the blocking remote signer grpc server call.
This also meant that chainNodes could not be used in conjunction with the grpc remote signer.