### PR TITLE
docs: add CODE_OF_CONDUCT.md, SECURITY.md, and CONTRIBUTING.md 

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socioeconomic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+support@strange.love.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,53 @@
+# Contributor Guidelines
+
+## Introduction
+
+Welcome to the Strangelove contributor guidelines. We are excited to have you here and look forward to your contributions!
+Contributors are expected to adhere to the guidelines outlined in this document as well as our [code of conduct](./CODE_OF_CONDUCT.md).
+
+##  Contributing
+
+There are many ways to contribute, from writing tutorials or blog posts, improving the documentation,
+submitting bug reports and feature requests, or writing code which can be incorporated into the project itself.
+
+### Bug Reports
+
+First thing to note is that if you believe you have discovered a security vulnerability *DO NOT* use the public issue tracker.
+Please read our [security policy](./SECURITY.md) for more information on reporting security vulnerabilities.
+
+When creating a bug report, please use the [template](./.github/ISSUE_TEMPLATE/bug_report.yml) and include as much
+detail as possible. At a minimum be sure to include the following:
+- What you were trying to do
+- How the bug can be reproduced
+- What you expected to happen
+- What version of the software you were using
+
+### Feature Requests & Enhancements
+
+Feature requests and other enhancements can be made using the [template](./.github/ISSUE_TEMPLATE/feature_request.yml) provided.
+Please provide as much detail as possible, including the problem you are trying to solve and the solution you would like to see,
+along with possible alternatives you have considered if applicable. Understanding the use cases and the benefits the new feature
+or enhancement would bring to users helps the team to prioritize and implement the feature.
+
+### Doc Changes
+
+Documentation changes are always welcome. If you see a typo, or would like to improve the documentation in any way feel
+free to open a PR. If you are unsure about the changes you would like to make or if the changes go well beyond
+addressing simple grammar mistakes or formatting, open an issue to discuss the changes before opening a PR.
+
+### Opening PRs
+
+When opening new PRs it is advised to open an issue first to discuss the changes you would like to make.
+This helps to ensure that the changes are in line with the project goals and that the team is aware of the changes being made
+so that duplicate efforts are not made and everyone's time is used efficiently.
+
+When opening a PR, please ensure that the PR description includes the issue number that the PR is addressing.
+This helps to ensure that the PR is linked to the issue and that the issue is closed when the PR is merged.
+
+
+### Contributor License Agreement
+
+Before opening a PR, please review LICENSE.md and familiarize yourself with its terms.
+Please be advised that by opening a PR, you are granting Strangelove (or the owner of the relevant repository) a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable license, in copyright and in patent, with respect to your
+Contribution and any portion thereof.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,22 @@
+golangci_lint_cmd=golangci-lint
+golangci_version=v1.57.2
+gofumpt_cmd=gofumpt
+gofumpt_version=v0.6.0
+
 VERSION := $(shell echo $(shell git describe --tags) | sed 's/^v//')
 COMMIT  := $(shell git log -1 --format='%H')
+
+default: help
+
+.PHONY: help
+## help: Prints this help message
+help: Makefile
+	@echo
+	@echo "Available make commands:"
+	@echo
+	@sed -n 's/^##//p' $< | column -t -s ':' |  sed -e 's/^/ /'
+	@echo
+
 
 all: install
 
@@ -57,3 +74,30 @@ proto-lint:
 
 
 .PHONY: all lint test race msan tools clean build
+
+.PHONY: lint
+## lint: Lint the repository
+lint:
+	@echo "--> Running linter"
+	@if ! $(golangci_lint_cmd) --version 2>/dev/null | grep -q $(golangci_version); then \
+        go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(golangci_version); \
+  fi
+	      @$(golangci_lint_cmd) run ./... --timeout 15m
+
+.PHONY: lint-fix
+## lint-fix: Lint the repository and fix warnings (if applicable)
+lint-fix:
+	@echo "--> Running linter and fixing issues"
+	@if ! $(golangci_lint_cmd) --version 2>/dev/null | grep -q $(golangci_version); then \
+		go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(golangci_version); \
+	fi
+	@$(golangci_lint_cmd) run ./... --fix --timeout 15m
+
+.PHONY: gofumpt
+## gofumpt: Format the code with gofumpt
+gofumpt:
+	@echo "--> Running gofumpt"
+	@if ! $(gofumpt_cmd) -version 2>/dev/null | grep -q $(gofumpt_version); then \
+		go install mvdan.cc/gofumpt@$(gofumpt_version); \
+	fi
+	@gofumpt -l -w .

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,12 @@
+# Reporting Security Issues
+
+The Strangelove team and the IBC community take security issues seriously. We appreciate your efforts to responsibly disclose your findings, and we will make all reasonable efforts to acknowledge your contributions.
+
+To report a security issue, please use the GitHub Security Advisory ["Report a Vulnerability"](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability) tab. Please provide any data you have, and the more you can provide the more rapidly we can respond. However, do not let lack of knowledge delay your report. You may leave blank any areas of the security advisory except the detailed description of the issue, the steps to reproduce, and the version or versions you know to be affected.
+
+The Strangelove team will send a response indicating the next steps in handling your report. After the initial reply to your report, the security team will keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance. We may also coordinate with Amulet or other security consultants in the Cosmos/IBC space.
+
+Report security bugs in third-party modules or plugins to the person or team maintaining the module.
+
+The GitHub Security Advisory "Report a Vulnerability" tab should always be the first step in reporting a security related issue.
+If for some reason you are unable to report through GitHub, please contact the Strangelove team at security@strange.love.


### PR DESCRIPTION
This PR adds the various artifacts that one would expect to find in a GitHub repo. This is the first step to bringing the horcrux repo into compliance with our OSS template.