### PR TITLE
ci: configure additional CI jobs & bring linter settings in compliance with OSS template

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,4 @@
+[codespell]
+skip = *.pulsar.go,*.pb.go,*.pb.gw.go,*.bin,*.sum,*.mod,*.git,*.json
+ignore-words-list = usera,pres,crate
+quiet-level = 3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  # check dependencies in go.mod
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+  # checks dependencies in github workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,15 @@
+# This mergify configuration is used for backporting only. This setup
+# will backport a PR after being approved if it has the label 'backport'.
+# Please see the comments below for configuring branches, labels, etc.
+#
+pull_request_rules:
+  - name: backport to maintained branches
+    conditions:
+      - label=backport # create a label in your project called backport
+    actions:
+      backport:
+        branches: # the list of branches the pull request should be copied to.
+          - main
+        assignees: # assign newly created backport PR to author
+            - "{{ author }}"
+        title: "`[BP: {{ destination_branch }} <- #{{ number }}]` {{ title }}"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,61 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ main ]
+  schedule:
+    - cron: '59 23 * * 5'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'go' ]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
+        # Learn more:
+        # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+
+    # Autobuild attempts to build any compiled languages.
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v3
+
+    # ✏️ If the Autobuild fails above, remove it and uncomment the following lines
+    #    and modify them (or add more) to build your code.
+
+    #- run: |
+    #   make install
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,6 @@
-name: golangci-lint
+# Lint the entire golang project. This workflow relies on the
+# '.golangci.yml' file for its configuration settings.
+name: Lint
 on:
   push:
     tags:
@@ -7,15 +9,26 @@ on:
       - master
       - main
   pull_request:
+
+permissions:
+  contents: read
+
+env:
+  GO_VERSION: 1.21
+
 jobs:
   golangci:
-    name: lint
+    name: golangci-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+      - uses: actions/setup-go@v5
         with:
-          version: latest
-          only-new-issues: true
-          args: --timeout=3m
+          go-version: ${{ env.GO_VERSION }}
+
+      - uses: actions/checkout@v4
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6.1.0
+        with:
+          version: v1.57.2
+          args: --timeout 15m

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -1,0 +1,11 @@
+name: Markdown Link Check
+
+on:
+  pull_request:
+
+jobs:
+  link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gaurav-nelson/github-action-markdown-link-check@1.0.15

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,0 +1,24 @@
+name: Spell Check
+
+on:
+  pull_request:
+
+jobs:
+  spellcheck:
+    name: Run codespell
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+
+    - name: Install codespell
+      run: pip install codespell
+
+    - name: Run codespell
+      run: codespell

--- a/.github/workflows/title-format.yml
+++ b/.github/workflows/title-format.yml
@@ -1,0 +1,20 @@
+name: "Lint PR Title"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,29 +1,70 @@
+run:
+  timeout: 10m
+  tests: true
+
+# These linter checks can be modified on a per project basis.
+# Simply remove them from the enable list to disable them.
 linters:
+  disable-all: true
   enable:
+    - asciicheck
+    - bidichk
     - bodyclose
-    - dogsled
+    - decorder
+    - dupl
+    - dupword
+    - errcheck
+    - errchkjson
+    - errname
+    - exhaustive
+    - exportloopref
+    - forbidigo
+    - gci
     - goconst
     - gocritic
-    - gofmt
-    - goimports
+    - godot
+    - gofumpt
     - gosec
     - gosimple
+    - gosmopolitan
     - govet
-    - importas
+    - grouper
     - ineffassign
-    - lll
+    - loggercheck
     - misspell
-    - nakedret
-    - prealloc
-    - revive
+    - nilerr
+    - nilnil
+    - noctx
     - staticcheck
     - stylecheck
+    - testifylint
+    - thelper
+    - tparallel
     - typecheck
     - unconvert
+    - unparam
     - unused
-    - nolintlint
+    - usestdlibvars
+    - wastedassign
+    - whitespace
 
 linters-settings:
+  gci:
+    custom-order: true
+    sections:
+      - standard # Standard section: captures all standard packages.
+      - default # Default section: contains all imports that could not be matched to another section type.
+      - blank # blank imports
+      - dot # dot imports
+      - prefix(cosmossdk.io)
+      - prefix(github.com/cosmos)
+      - prefix(github.com/cosmos/cosmos-sdk)
+      - prefix(github.com/cometbft/cometbft)
+      # TODO: Replace below with '- prefix(<project-package-name>)'
+      - prefix(github.com/strangelove-ventures/horcrux)
+  gosec:
+    excludes:
+      - G404 # disables checks on insecure random number source
   dogsled:
     max-blank-identifiers: 3
   importas:
@@ -99,8 +140,6 @@ linters-settings:
         alias: boltdb
       - pkg: math/rand
         alias: mrand
-  maligned:
-    suggest-new: true
-  govet:
-    misspell:
-      locale: US
+
+issues:
+  max-issues-per-linter: 0


### PR DESCRIPTION
This PR adds some additional CI jobs:

- Codespell (which checks for grammar mistakes)
- Dependabot (which monitors for out of date deps and security vulnerabilities)
- Mergify (which can be used for automatically backporting commits across maintained versions)
- CodeQL (which looks for code smells, security vulnerabilities, etc.)
- Markdown Link Checker (which looks for broken markdown hyperlinks)
- Title Format (which enforces conventional commits in PR titles)


It also tweaks the golangci-lint settings to be in compliance with the OSS template.

TODO: Do we bring the build & test CI job and the goreleaser CI job into compliance with the OSS template or do we leave the currently configured settings?