### PR TITLE
Fix typo metrics.go

### DIFF
--- a/signer/metrics.go
+++ b/signer/metrics.go
@@ -252,7 +252,7 @@ var (
 	failedSignVote = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "signer_total_failed_sign_vote",
-			Help: "Total Times Signer Failed to sign block - Unstarted and Unexepcted Height",
+			Help: "Total Times Signer Failed to sign block - Unstarted and Unexpected Height",
 		},
 		[]string{"chain_id"},
 	)


### PR DESCRIPTION
### Summary
Fixes a typo in the `metrics.go` file.

### Changes
- Corrected "Unexepcted" to "Unexpected" in the `failedSignVote` counter help text.

### Notes
- This is a minor change affecting only the help text for a metric.
