### PR TITLE
fix:  correct GRPC address flag name 

### DIFF
--- a/cmd/horcrux/cmd/config.go
+++ b/cmd/horcrux/cmd/config.go
@@ -18,7 +18,7 @@ const (
 	flagGRPCTimeout = "grpc-timeout"
 	flagOverwrite   = "overwrite"
 	flagBare        = "bare"
-	flagGRPCAddress = "gprc-address"
+	flagGRPCAddress = "grpc-address"
 	flagMaxReadSize = "max-read-size"
 )
 


### PR DESCRIPTION

Fixed CLI flag name from "gprc-address" to "grpc-address" to match correct GRPC protocol name.