### PR TITLE
fix typos: "liveliness" to "liveness" and "seperate" to "separate"

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Take your validator infrastructure to the next level of security and availabilit
 
 ## Design
 
-Validator operators balance operational and risk tradeoffs to avoid penalties via slashing for liveliness faults or double signing blocks.
+Validator operators balance operational and risk tradeoffs to avoid penalties via slashing for liveness faults or double signing blocks.
 
 Traditional high-availability systems where the keys exist on hot spares risk double signing if there are failover detection bugs. Low-availability systems, or manual failover, risk downtime if manual intervention cannot respond in a timely manner.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -34,7 +34,7 @@ To get started, follow these steps:
    git clone https://github.com/<Username>/horcrux.git
    ```
 
-3. Crate a new branch on your fork
+3. Create a new branch on your fork
 
     ```sh
     git checkout -b name/broad-description-of-feature    

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -206,7 +206,7 @@ The signer will continue retrying attempts to reach the sentries until we turn t
 - Misnaming or incorrect structure of the files in `~/.horcrux/state`. Double check these if you see errors
 - Misnaming or misplacement of the `~/.horcrux/{chain-id}_shard.json` file
 
-> **NOTE:** leaving these logs streaming in seperate terminal windows will enable you to watch the cluster connect to the sentries.
+> **NOTE:** leaving these logs streaming in separate terminal windows will enable you to watch the cluster connect to the sentries.
 
 ### 8. Configure and start your full nodes
 


### PR DESCRIPTION
This PR fixes two typos in the documentation:
- Changed "liveliness" to "liveness" in README.md
- Changed "seperate" to "separate" in docs/migrating.md

These changes improve the documentation accuracy and readability.