### PR TITLE
Update checkout action from v3 to v4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
 
       # checkout horcrux
       - name: checkout horcrux
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # run tests
       - name: run horcrux tests
@@ -54,7 +54,7 @@ jobs:
 
       # checkout horcrux
       - name: checkout horcrux
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # run test matrix
       - name: run test


### PR DESCRIPTION
Updates GitHub's checkout action from version 3 to version 4 in the test workflow.

Changes made:
- Updated `actions/checkout@v3` to `actions/checkout@v4` in two places in the workflow file
- This update ensures we're using the latest version of the checkout action with its improvements and bug fixes

This is a maintenance update to keep our GitHub Actions workflows up to date with the latest stable versions.