### PR TITLE
Fix amnesia faults vulnerability #308

### DIFF
--- a/cmd/horcrux/cmd/config.go
+++ b/cmd/horcrux/cmd/config.go
@@ -43,7 +43,7 @@ func initCmd() *cobra.Command {
 for threshold signer mode, --cosigner flags and --threshold flag are required.
 		`,
 		Args: cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) (err error) {
+		RunE: func(cmd *cobra.Command, _ []string) (err error) {
 			cmdFlags := cmd.Flags()
 
 			bare, _ := cmdFlags.GetBool(flagBare)

--- a/cmd/horcrux/cmd/leader_election.go
+++ b/cmd/horcrux/cmd/leader_election.go
@@ -30,7 +30,7 @@ To choose a specific leader, pass that leader's ID as an argument.
 		Example: `horcrux elect # elect next eligible leader
 horcrux elect 2 # elect specific leader`,
 		SilenceUsage: true,
-		RunE: func(cmd *cobra.Command, args []string) (err error) {
+		RunE: func(cmd *cobra.Command, _ []string) (err error) {
 			if config.Config.ThresholdModeConfig == nil {
 				return fmt.Errorf("threshold mode configuration is not present in config file")
 			}
@@ -97,7 +97,7 @@ func getLeaderCmd() *cobra.Command {
 		Args:         cobra.NoArgs,
 		Example:      `horcrux leader`,
 		SilenceUsage: true,
-		RunE: func(cmd *cobra.Command, args []string) (err error) {
+		RunE: func(cmd *cobra.Command, _ []string) (err error) {
 			thresholdCfg := config.Config.ThresholdModeConfig
 			if thresholdCfg == nil {
 				return fmt.Errorf("threshold mode configuration is not present in config file")

--- a/cmd/horcrux/cmd/shards.go
+++ b/cmd/horcrux/cmd/shards.go
@@ -66,7 +66,7 @@ func createCosignerEd25519ShardsCmd() *cobra.Command {
 		Use:   "create-ed25519-shards",
 		Args:  cobra.NoArgs,
 		Short: "Create cosigner Ed25519 shards",
-		RunE: func(cmd *cobra.Command, args []string) (err error) {
+		RunE: func(cmd *cobra.Command, _ []string) (err error) {
 			flags := cmd.Flags()
 
 			chainID, _ := flags.GetString(flagChainID)
@@ -163,7 +163,7 @@ func createCosignerECIESShardsCmd() *cobra.Command {
 		Args:  cobra.NoArgs,
 		Short: "Create cosigner ECIES shards",
 
-		RunE: func(cmd *cobra.Command, args []string) (err error) {
+		RunE: func(cmd *cobra.Command, _ []string) (err error) {
 			shards, _ := cmd.Flags().GetUint8(flagShards)
 
 			if shards <= 0 {
@@ -211,7 +211,7 @@ func createCosignerRSAShardsCmd() *cobra.Command {
 		Args:  cobra.NoArgs,
 		Short: "Create cosigner RSA shards",
 
-		RunE: func(cmd *cobra.Command, args []string) (err error) {
+		RunE: func(cmd *cobra.Command, _ []string) (err error) {
 			shards, _ := cmd.Flags().GetUint8(flagShards)
 
 			if shards <= 0 {

--- a/cmd/horcrux/cmd/start.go
+++ b/cmd/horcrux/cmd/start.go
@@ -16,7 +16,7 @@ func startCmd() *cobra.Command {
 		Short:        "Start horcrux signer process",
 		Args:         cobra.NoArgs,
 		SilenceUsage: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			out := cmd.OutOrStdout()
 			logger := cometlog.NewTMLogger(cometlog.NewSyncWriter(out))
 

--- a/cmd/horcrux/cmd/version.go
+++ b/cmd/horcrux/cmd/version.go
@@ -68,7 +68,7 @@ func versionCmd() *cobra.Command {
 		Use:          "version",
 		Short:        "Version information for horcrux",
 		SilenceUsage: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			bz, err := json.MarshalIndent(NewInfo(), "", "  ")
 			if err != nil {
 				return err

--- a/docker/horcrux/Dockerfile.alternative
+++ b/docker/horcrux/Dockerfile.alternative
@@ -1,18 +1,16 @@
 FROM --platform=$BUILDPLATFORM golang:1.21-alpine AS build-env
 
-RUN apk add --update --no-cache curl make git libc-dev bash gcc linux-headers eudev-dev wget
+# Install cross-compilation tools from Alpine packages instead of musl.cc
+RUN apk add --update --no-cache curl make git libc-dev bash gcc linux-headers eudev-dev
 
 ARG TARGETARCH
 ARG BUILDARCH
 
+# Use Alpine's cross-compilation packages instead of downloading from musl.cc
 RUN if [ "${TARGETARCH}" = "arm64" ] && [ "${BUILDARCH}" != "arm64" ]; then \
-        for i in 1 2 3; do \
-            wget -c https://musl.cc/aarch64-linux-musl-cross.tgz -O - | tar -xzvv --strip-components 1 -C /usr && break || sleep 5; \
-        done; \
+        apk add --no-cache gcc-aarch64-linux-gnu musl-dev; \
     elif [ "${TARGETARCH}" = "amd64" ] && [ "${BUILDARCH}" != "amd64" ]; then \
-        for i in 1 2 3; do \
-            wget -c https://musl.cc/x86_64-linux-musl-cross.tgz -O - | tar -xzvv --strip-components 1 -C /usr && break || sleep 5; \
-        done; \
+        apk add --no-cache gcc-x86_64-linux-gnu musl-dev; \
     fi
 
 WORKDIR /horcrux
@@ -20,9 +18,9 @@ WORKDIR /horcrux
 ADD . .
 
 RUN if [ "${TARGETARCH}" = "arm64" ] && [ "${BUILDARCH}" != "arm64" ]; then \
-        export CC=aarch64-linux-musl-gcc CXX=aarch64-linux-musl-g++;\
+        export CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++;\
     elif [ "${TARGETARCH}" = "amd64" ] && [ "${BUILDARCH}" != "amd64" ]; then \
-        export CC=x86_64-linux-musl-gcc CXX=x86_64-linux-musl-g++; \
+        export CC=x86_64-linux-gnu-gcc CXX=x86_64-linux-gnu-g++; \
     fi; \
     GOOS=linux GOARCH=$TARGETARCH CGO_ENABLED=1 LDFLAGS='-linkmode external -extldflags "-static"' make install
 

--- a/proto/strangelove/horcrux/cosigner.proto
+++ b/proto/strangelove/horcrux/cosigner.proto
@@ -19,6 +19,7 @@ message Block {
 	bytes signBytes = 4;
 	bytes voteExtSignBytes = 5;
 	int64 timestamp = 6;
+	int64 pol_round = 7;
 }
 
 message SignBlockRequest {

--- a/signer/consensus_lock_e2e_test.go
+++ b/signer/consensus_lock_e2e_test.go
@@ -95,7 +95,7 @@ func TestConsensusLockE2E(t *testing.T) {
 
 	// Test 6: After signing a PRECOMMIT for a different block, the lock should be updated
 	// Simulate the lock update
-	newLock := updateConsensusLock(signState.ConsensusLock, HRSKey{Height: 100, Round: 6, Step: stepPrecommit}, differentBlockPrecommit)
+	newLock := nextConsensusLock(signState.ConsensusLock, HRSKey{Height: 100, Round: 6, Step: stepPrecommit}, differentBlockPrecommit)
 	require.True(t, newLock.IsLocked(), "New lock should be active")
 	require.Equal(t, int64(100), newLock.Height, "Lock should be at height 100")
 	require.Equal(t, int64(6), newLock.Round, "Lock should be at round 6")
@@ -153,7 +153,7 @@ func TestConsensusLockRealWorldScenario(t *testing.T) {
 	require.NoError(t, err, "Should allow PRECOMMIT for block B (releases lock)")
 
 	// After signing PRECOMMIT for block B, validator should be locked on block B
-	newLock := updateConsensusLock(signState.ConsensusLock, HRSKey{Height: 100, Round: 6, Step: stepPrecommit}, blockBPrecommit)
+	newLock := nextConsensusLock(signState.ConsensusLock, HRSKey{Height: 100, Round: 6, Step: stepPrecommit}, blockBPrecommit)
 	require.True(t, newLock.IsLocked(), "Should be locked on block B")
 	require.Equal(t, blockB, newLock.Value, "Lock should be on block B")
 	require.Equal(t, int64(6), newLock.Round, "Lock should be at round 6")

--- a/signer/consensus_lock_e2e_test.go
+++ b/signer/consensus_lock_e2e_test.go
@@ -1,0 +1,200 @@
+package signer
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cometbft/cometbft/libs/protoio"
+	cometproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	"github.com/stretchr/testify/require"
+)
+
+// createTestSignBytes creates proper Tendermint sign bytes for testing
+func createTestSignBytesE2E(blockHash []byte, step int8) []byte {
+	switch step {
+	case stepPropose:
+		// Create a CanonicalProposal
+		proposal := &cometproto.CanonicalProposal{
+			Type:   cometproto.ProposalType,
+			Height: 100,
+			Round:  5,
+			BlockID: &cometproto.CanonicalBlockID{
+				Hash: blockHash,
+			},
+		}
+		signBytes, _ := protoio.MarshalDelimited(proposal)
+		return signBytes
+
+	case stepPrevote, stepPrecommit:
+		// Create a CanonicalVote
+		vote := &cometproto.CanonicalVote{
+			Type:   cometproto.SignedMsgType(step),
+			Height: 100,
+			Round:  5,
+			BlockID: &cometproto.CanonicalBlockID{
+				Hash: blockHash,
+			},
+		}
+		signBytes, _ := protoio.MarshalDelimited(vote)
+		return signBytes
+
+	default:
+		return nil
+	}
+}
+
+// TestConsensusLockE2E tests the consensus lock functionality end-to-end
+// This test simulates a real scenario where a validator tries to sign conflicting blocks
+func TestConsensusLockE2E(t *testing.T) {
+	// Create a sign state that simulates a validator that has already signed a PRECOMMIT
+	// for a specific block at height 100, round 5
+	lockedBlockHash := []byte("locked_block_hash_123456789012345678901234567890")[:32] // Ensure exactly 32 bytes
+	signState := &SignState{
+		Height: 100,
+		Round:  5,
+		Step:   stepPrecommit,
+		ConsensusLock: ConsensusLock{
+			Height: 100,
+			Round:  5,
+			Value:  lockedBlockHash,
+		},
+	}
+
+	// Test 1: Validator tries to sign a PROPOSAL for the same block in a later round
+	// This should be allowed (same value)
+	sameBlockProposal := createTestSignBytesE2E(lockedBlockHash, stepPropose)
+	err := signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 6, Step: stepPropose}, sameBlockProposal)
+	require.NoError(t, err, "Should allow PROPOSAL for same block in later round")
+
+	// Test 2: Validator tries to sign a PREVOTE for the same block in a later round
+	// This should be allowed (same value)
+	sameBlockPrevote := createTestSignBytesE2E(lockedBlockHash, stepPrevote)
+	err = signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 6, Step: stepPrevote}, sameBlockPrevote)
+	require.NoError(t, err, "Should allow PREVOTE for same block in later round")
+
+	// Test 3: Validator tries to sign a PROPOSAL for a different block in a later round
+	// This should be blocked (different value)
+	differentBlockHash := []byte("different_block_hash_123456789012345678901234567890")[:32]
+	differentBlockProposal := createTestSignBytesE2E(differentBlockHash, stepPropose)
+	err = signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 6, Step: stepPropose}, differentBlockProposal)
+	require.Error(t, err, "Should block PROPOSAL for different block in later round")
+	require.True(t, IsConsensusLockViolationError(err), "Should be a consensus lock violation error")
+
+	// Test 4: Validator tries to sign a PREVOTE for a different block in a later round
+	// This should be blocked (different value)
+	differentBlockPrevote := createTestSignBytesE2E(differentBlockHash, stepPrevote)
+	err = signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 6, Step: stepPrevote}, differentBlockPrevote)
+	require.Error(t, err, "Should block PREVOTE for different block in later round")
+	require.True(t, IsConsensusLockViolationError(err), "Should be a consensus lock violation error")
+
+	// Test 5: Validator tries to sign a PRECOMMIT for a different block in a later round
+	// This should be allowed (PRECOMMIT releases the lock)
+	differentBlockPrecommit := createTestSignBytesE2E(differentBlockHash, stepPrecommit)
+	err = signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 6, Step: stepPrecommit}, differentBlockPrecommit)
+	require.NoError(t, err, "Should allow PRECOMMIT for different block in later round (releases lock)")
+
+	// Test 6: After signing a PRECOMMIT for a different block, the lock should be updated
+	// Simulate the lock update
+	newLock := updateConsensusLock(signState.ConsensusLock, HRSKey{Height: 100, Round: 6, Step: stepPrecommit}, differentBlockPrecommit)
+	require.True(t, newLock.IsLocked(), "New lock should be active")
+	require.Equal(t, int64(100), newLock.Height, "Lock should be at height 100")
+	require.Equal(t, int64(6), newLock.Round, "Lock should be at round 6")
+	require.Equal(t, differentBlockHash, newLock.Value, "Lock should be on the new block")
+
+	// Test 7: Validator tries to sign for a different height
+	// This should be allowed (locks are height-specific)
+	differentHeightBytes := createTestSignBytesE2E(differentBlockHash, stepPropose)
+	err = signState.ValidateConsensusLock(HRSKey{Height: 101, Round: 1, Step: stepPropose}, differentHeightBytes)
+	require.NoError(t, err, "Should allow signing for different height")
+
+	// Test 8: Validator tries to sign for the same height but earlier round
+	// This should be allowed (locks only apply to later rounds)
+	err = signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 4, Step: stepPropose}, differentHeightBytes)
+	require.NoError(t, err, "Should allow signing for earlier round")
+}
+
+// TestConsensusLockRealWorldScenario tests a realistic scenario
+func TestConsensusLockRealWorldScenario(t *testing.T) {
+	// Scenario: Validator is locked on block A at height 100, round 5
+	// Network times out and moves to round 6
+	// New block B is proposed in round 6
+	// Validator should be prevented from signing block B until it signs a PRECOMMIT
+
+	lockedBlockA := []byte("block_A_hash_123456789012345678901234567890")[:32]
+	signState := &SignState{
+		Height: 100,
+		Round:  5,
+		Step:   stepPrecommit,
+		ConsensusLock: ConsensusLock{
+			Height: 100,
+			Round:  5,
+			Value:  lockedBlockA,
+		},
+	}
+
+	// Round 6: New block B is proposed
+	blockB := []byte("block_B_hash_123456789012345678901234567890")[:32]
+
+	// Validator should NOT be able to sign PROPOSAL for block B
+	blockBProposal := createTestSignBytesE2E(blockB, stepPropose)
+	err := signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 6, Step: stepPropose}, blockBProposal)
+	require.Error(t, err, "Should block PROPOSAL for block B")
+	require.True(t, IsConsensusLockViolationError(err), "Should be a consensus lock violation")
+
+	// Validator should NOT be able to sign PREVOTE for block B
+	blockBPrevote := createTestSignBytesE2E(blockB, stepPrevote)
+	err = signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 6, Step: stepPrevote}, blockBPrevote)
+	require.Error(t, err, "Should block PREVOTE for block B")
+	require.True(t, IsConsensusLockViolationError(err), "Should be a consensus lock violation")
+
+	// Validator should be able to sign PRECOMMIT for block B (this releases the lock)
+	blockBPrecommit := createTestSignBytesE2E(blockB, stepPrecommit)
+	err = signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 6, Step: stepPrecommit}, blockBPrecommit)
+	require.NoError(t, err, "Should allow PRECOMMIT for block B (releases lock)")
+
+	// After signing PRECOMMIT for block B, validator should be locked on block B
+	newLock := updateConsensusLock(signState.ConsensusLock, HRSKey{Height: 100, Round: 6, Step: stepPrecommit}, blockBPrecommit)
+	require.True(t, newLock.IsLocked(), "Should be locked on block B")
+	require.Equal(t, blockB, newLock.Value, "Lock should be on block B")
+	require.Equal(t, int64(6), newLock.Round, "Lock should be at round 6")
+
+	// Update the signState with the new lock
+	signState.ConsensusLock = newLock
+
+	// Now validator should NOT be able to sign for block A in round 7
+	blockAProposal := createTestSignBytesE2E(lockedBlockA, stepPropose)
+	err = signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 7, Step: stepPropose}, blockAProposal)
+	require.Error(t, err, "Should block PROPOSAL for block A in round 7")
+	require.True(t, IsConsensusLockViolationError(err), "Should be a consensus lock violation")
+}
+
+// TestConsensusLockPerformanceE2E tests that consensus lock validation is fast enough for production use
+func TestConsensusLockPerformanceE2E(t *testing.T) {
+	signState := &SignState{
+		Height: 100,
+		Round:  5,
+		Step:   stepPrecommit,
+		ConsensusLock: ConsensusLock{
+			Height: 100,
+			Round:  5,
+			Value:  []byte("locked_block_hash_123456789012345678901234567890")[:32],
+		},
+	}
+
+	blockHash := []byte("different_block_hash_123456789012345678901234567890")[:32]
+	blockBytes := createTestSignBytesE2E(blockHash, stepPropose)
+
+	// Test that validation is fast (should complete in < 1ms per operation)
+	start := time.Now()
+	for i := 0; i < 10000; i++ {
+		err := signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 6, Step: stepPropose}, blockBytes)
+		require.Error(t, err) // Should always fail due to lock violation
+	}
+	duration := time.Since(start)
+
+	// Should complete 10,000 validations in well under 1 second
+	require.Less(t, duration, time.Second, "Consensus lock validation should be very fast")
+
+	avgTimePerOp := duration / 10000
+	require.Less(t, avgTimePerOp, 100*time.Microsecond, "Average time per operation should be < 100μs")
+}

--- a/signer/consensus_lock_integration_test.go
+++ b/signer/consensus_lock_integration_test.go
@@ -1,0 +1,65 @@
+package signer
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestConsensusLockIntegration tests that consensus lock doesn't interfere with normal signing operations
+func TestConsensusLockIntegration(t *testing.T) {
+	// Create a simple sign state with no existing lock
+	signState := &SignState{
+		Height:        100,
+		Round:         5,
+		Step:          stepPrecommit,
+		ConsensusLock: ConsensusLock{}, // No lock initially
+	}
+
+	// Test that we can sign a PROPOSAL without issues
+	proposalBytes := []byte("proposal_block_hash_123456789012345678901234567890")
+	err := signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 5, Step: stepPropose}, proposalBytes)
+	require.NoError(t, err, "Should allow PROPOSAL signing when no lock exists")
+
+	// Test that we can sign a PREVOTE without issues
+	prevoteBytes := []byte("prevote_block_hash_123456789012345678901234567890")
+	err = signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 5, Step: stepPrevote}, prevoteBytes)
+	require.NoError(t, err, "Should allow PREVOTE signing when no lock exists")
+
+	// Test that we can sign a PRECOMMIT without issues
+	precommitBytes := []byte("precommit_block_hash_123456789012345678901234567890")
+	err = signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 5, Step: stepPrecommit}, precommitBytes)
+	require.NoError(t, err, "Should allow PRECOMMIT signing when no lock exists")
+
+	// Test that we can sign at different heights without issues
+	err = signState.ValidateConsensusLock(HRSKey{Height: 101, Round: 1, Step: stepPropose}, proposalBytes)
+	require.NoError(t, err, "Should allow signing at different height")
+
+	// Test that we can sign at different rounds within same height without issues
+	err = signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 6, Step: stepPropose}, proposalBytes)
+	require.NoError(t, err, "Should allow signing at different round within same height")
+}
+
+// TestConsensusLockPerformance tests that consensus lock validation is fast
+func TestConsensusLockPerformance(t *testing.T) {
+	signState := &SignState{
+		Height:        100,
+		Round:         5,
+		Step:          stepPrecommit,
+		ConsensusLock: ConsensusLock{}, // No lock initially
+	}
+
+	blockBytes := []byte("block_hash_123456789012345678901234567890")
+
+	// Test that validation is fast (should complete in < 1ms)
+	start := time.Now()
+	for i := 0; i < 1000; i++ {
+		err := signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 5, Step: stepPropose}, blockBytes)
+		require.NoError(t, err)
+	}
+	duration := time.Since(start)
+
+	// Should complete 1000 validations in well under 1 second
+	require.Less(t, duration, time.Second, "Consensus lock validation should be fast")
+}

--- a/signer/consensus_lock_integration_test.go
+++ b/signer/consensus_lock_integration_test.go
@@ -19,25 +19,25 @@ func TestConsensusLockIntegration(t *testing.T) {
 
 	// Test that we can sign a PROPOSAL without issues
 	proposalBytes := []byte("proposal_block_hash_123456789012345678901234567890")
-	err := signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 5, Step: stepPropose}, proposalBytes)
+	err := signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 5, Step: stepPropose}, proposalBytes, -2)
 	require.NoError(t, err, "Should allow PROPOSAL signing when no lock exists")
 
 	// Test that we can sign a PREVOTE without issues
 	prevoteBytes := []byte("prevote_block_hash_123456789012345678901234567890")
-	err = signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 5, Step: stepPrevote}, prevoteBytes)
+	err = signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 5, Step: stepPrevote}, prevoteBytes, -2)
 	require.NoError(t, err, "Should allow PREVOTE signing when no lock exists")
 
 	// Test that we can sign a PRECOMMIT without issues
 	precommitBytes := []byte("precommit_block_hash_123456789012345678901234567890")
-	err = signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 5, Step: stepPrecommit}, precommitBytes)
+	err = signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 5, Step: stepPrecommit}, precommitBytes, -2)
 	require.NoError(t, err, "Should allow PRECOMMIT signing when no lock exists")
 
 	// Test that we can sign at different heights without issues
-	err = signState.ValidateConsensusLock(HRSKey{Height: 101, Round: 1, Step: stepPropose}, proposalBytes)
+	err = signState.ValidateConsensusLock(HRSKey{Height: 101, Round: 1, Step: stepPropose}, proposalBytes, -2)
 	require.NoError(t, err, "Should allow signing at different height")
 
 	// Test that we can sign at different rounds within same height without issues
-	err = signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 6, Step: stepPropose}, proposalBytes)
+	err = signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 6, Step: stepPropose}, proposalBytes, -2)
 	require.NoError(t, err, "Should allow signing at different round within same height")
 }
 
@@ -55,7 +55,7 @@ func TestConsensusLockPerformance(t *testing.T) {
 	// Test that validation is fast (should complete in < 1ms)
 	start := time.Now()
 	for i := 0; i < 1000; i++ {
-		err := signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 5, Step: stepPropose}, blockBytes)
+		err := signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 5, Step: stepPropose}, blockBytes, -2)
 		require.NoError(t, err)
 	}
 	duration := time.Since(start)

--- a/signer/consensus_lock_simple_test.go
+++ b/signer/consensus_lock_simple_test.go
@@ -54,7 +54,7 @@ func TestConsensusLockBasic(t *testing.T) {
 
 	// Test that no lock means no validation error
 	blockBytes := []byte("some_block_data_123456789012345678901234567890")
-	err := signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 5, Step: stepPrevote}, blockBytes)
+	err := signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 5, Step: stepPrevote}, blockBytes, -2)
 	if err != nil {
 		t.Errorf("Expected no error when no lock exists, got: %v", err)
 	}
@@ -100,7 +100,7 @@ func TestConsensusLockValidationWithLock(t *testing.T) {
 
 	// Test 1: Try to sign the same block at same round (should succeed)
 	sameBlockBytes := createTestSignBytes(lockedValue[:32], stepPrevote)
-	err := signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 5, Step: stepPrevote}, sameBlockBytes)
+	err := signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 5, Step: stepPrevote}, sameBlockBytes, -2)
 	if err != nil {
 		t.Errorf("Expected no error when signing same block at same round, got: %v", err)
 	}
@@ -108,33 +108,33 @@ func TestConsensusLockValidationWithLock(t *testing.T) {
 	// Test 2: Try to sign a different block at the same round (should fail for PROPOSAL/PREVOTE)
 	differentBlockHash := []byte("different_block_hash_123456789012345678901234567890")[:32]
 	differentBlockBytes := createTestSignBytes(differentBlockHash, stepPrevote)
-	err = signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 5, Step: stepPrevote}, differentBlockBytes)
+	err = signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 5, Step: stepPrevote}, differentBlockBytes, -2)
 	if err == nil {
 		t.Error("Expected error when signing different block at same round, got nil")
 	}
 
 	// Test 3: Try to sign the locked value at a later round (should succeed)
-	err = signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 6, Step: stepPrevote}, sameBlockBytes)
+	err = signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 6, Step: stepPrevote}, sameBlockBytes, -2)
 	if err != nil {
 		t.Errorf("Expected no error when signing locked value at later round, got: %v", err)
 	}
 
 	// Test 4: Try to sign a different value at a later round (should fail for PROPOSAL/PREVOTE)
-	err = signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 6, Step: stepPrevote}, differentBlockBytes)
+	err = signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 6, Step: stepPrevote}, differentBlockBytes, -2)
 	if err == nil {
 		t.Error("Expected error when signing different value at later round, got nil")
 	}
 
 	// Test 5: Try to sign PRECOMMIT at later round (should succeed - releases lock)
 	precommitBytes := createTestSignBytes(differentBlockHash, stepPrecommit)
-	err = signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 6, Step: stepPrecommit}, precommitBytes)
+	err = signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 6, Step: stepPrecommit}, precommitBytes, -2)
 	if err != nil {
 		t.Errorf("Expected no error when signing PRECOMMIT at later round, got: %v", err)
 	}
 
 	// Test 6: Try to sign at a different height (should succeed - lock is released)
 	differentHeightBytes := createTestSignBytes(differentBlockHash, stepPrevote)
-	err = signState.ValidateConsensusLock(HRSKey{Height: 101, Round: 5, Step: stepPrevote}, differentHeightBytes)
+	err = signState.ValidateConsensusLock(HRSKey{Height: 101, Round: 5, Step: stepPrevote}, differentHeightBytes, -2)
 	if err != nil {
 		t.Errorf("Expected no error when signing at different height, got: %v", err)
 	}
@@ -157,7 +157,7 @@ func TestConsensusLockErrorTypes(t *testing.T) {
 	// Test that we get a ConsensusLockViolationError for conflicting values
 	differentBlockHash := []byte("different_block_hash_123456789012345678901234567890")[:32]
 	differentBlockBytes := createTestSignBytes(differentBlockHash, stepPrevote)
-	err := signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 6, Step: stepPrevote}, differentBlockBytes)
+	err := signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 6, Step: stepPrevote}, differentBlockBytes, -2)
 	if err == nil {
 		t.Error("Expected consensus lock violation error, got nil")
 	}
@@ -175,14 +175,14 @@ func TestConsensusLockErrorTypes(t *testing.T) {
 
 	// Test that we don't get an error for the same value
 	sameBlockBytes := createTestSignBytes(lockedValue[:32], stepPrevote)
-	err = signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 6, Step: stepPrevote}, sameBlockBytes)
+	err = signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 6, Step: stepPrevote}, sameBlockBytes, -2)
 	if err != nil {
 		t.Errorf("Expected no error for same value, got: %v", err)
 	}
 
 	// Test that we don't get an error for different height
 	differentHeightBytes := createTestSignBytes(differentBlockHash, stepPrevote)
-	err = signState.ValidateConsensusLock(HRSKey{Height: 101, Round: 5, Step: stepPrevote}, differentHeightBytes)
+	err = signState.ValidateConsensusLock(HRSKey{Height: 101, Round: 5, Step: stepPrevote}, differentHeightBytes, -2)
 	if err != nil {
 		t.Errorf("Expected no error for different height, got: %v", err)
 	}

--- a/signer/consensus_lock_simple_test.go
+++ b/signer/consensus_lock_simple_test.go
@@ -1,0 +1,153 @@
+package signer
+
+import (
+	"testing"
+)
+
+func TestConsensusLockBasic(t *testing.T) {
+	// Create a new sign state with no lock
+	signState := &SignState{
+		Height:        100,
+		Round:         5,
+		Step:          stepPrevote,
+		ConsensusLock: ConsensusLock{}, // No lock initially
+	}
+
+	// Test that no lock means no validation error
+	blockBytes := []byte("some_block_data_123456789012345678901234567890")
+	err := signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 5, Step: stepPrevote}, blockBytes)
+	if err != nil {
+		t.Errorf("Expected no error when no lock exists, got: %v", err)
+	}
+
+	// Test updating lock on PRECOMMIT
+	blockHash := []byte("new_block_hash_123456789012345678901234567890") // 32 bytes
+	signState.UpdateConsensusLock(HRSKey{Height: 100, Round: 5, Step: stepPrecommit}, blockHash)
+
+	if !signState.ConsensusLock.IsLocked() {
+		t.Error("Expected consensus lock to be set after PRECOMMIT")
+	}
+
+	if signState.ConsensusLock.Height != 100 {
+		t.Errorf("Expected lock height 100, got %d", signState.ConsensusLock.Height)
+	}
+
+	if signState.ConsensusLock.Round != 5 {
+		t.Errorf("Expected lock round 5, got %d", signState.ConsensusLock.Round)
+	}
+
+	// Test that lock is preserved correctly
+	expectedValue := blockHash[:32] // First 32 bytes
+	if string(signState.ConsensusLock.Value) != string(expectedValue) {
+		t.Errorf("Expected lock value %s, got %s", string(expectedValue), string(signState.ConsensusLock.Value))
+	}
+}
+
+func TestConsensusLockValidationWithLock(t *testing.T) {
+	// Create a sign state with a lock
+	lockedValue := []byte("locked_block_hash_123456789012345678901234567890")
+	signState := &SignState{
+		Height: 100,
+		Round:  5,
+		Step:   stepPrecommit,
+		ConsensusLock: ConsensusLock{
+			Height:    100,
+			Round:     5,
+			Value:     lockedValue[:32], // First 32 bytes
+			ValueType: "block",
+		},
+	}
+
+	// Test 1: Try to sign the same block at same round (should succeed)
+	sameBlockBytes := []byte("locked_block_hash_123456789012345678901234567890_other_data")
+	err := signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 5, Step: stepPrevote}, sameBlockBytes)
+	if err != nil {
+		t.Errorf("Expected no error when signing same block at same round, got: %v", err)
+	}
+
+	// Test 2: Try to sign a different block at the same round (should fail for PROPOSAL/PREVOTE)
+	differentBlockBytes := []byte("different_block_hash_123456789012345678901234567890_other_data")
+	err = signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 5, Step: stepPrevote}, differentBlockBytes)
+	if err == nil {
+		t.Error("Expected error when signing different block at same round, got nil")
+	}
+
+	// Test 3: Try to sign the locked value at a later round (should succeed)
+	err = signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 6, Step: stepPrevote}, sameBlockBytes)
+	if err != nil {
+		t.Errorf("Expected no error when signing locked value at later round, got: %v", err)
+	}
+
+	// Test 4: Try to sign a different value at a later round (should fail for PROPOSAL/PREVOTE)
+	err = signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 6, Step: stepPrevote}, differentBlockBytes)
+	if err == nil {
+		t.Error("Expected error when signing different value at later round, got nil")
+	}
+
+	// Test 5: Try to sign PRECOMMIT at later round (should succeed - releases lock)
+	err = signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 6, Step: stepPrecommit}, differentBlockBytes)
+	if err != nil {
+		t.Errorf("Expected no error when signing PRECOMMIT at later round, got: %v", err)
+	}
+
+	// Test 6: Try to sign at a different height (should succeed - lock is released)
+	err = signState.ValidateConsensusLock(HRSKey{Height: 101, Round: 5, Step: stepPrevote}, differentBlockBytes)
+	if err != nil {
+		t.Errorf("Expected no error when signing at different height, got: %v", err)
+	}
+}
+
+func TestConsensusLockClearing(t *testing.T) {
+	// Create a sign state with a lock
+	lockedValue := []byte("locked_block_hash_123456789012345678901234567890")
+	signState := &SignState{
+		Height: 100,
+		Round:  5,
+		Step:   stepPrecommit,
+		ConsensusLock: ConsensusLock{
+			Height:    100,
+			Round:     5,
+			Value:     lockedValue[:32], // First 32 bytes
+			ValueType: "block",
+		},
+	}
+
+	// Test 1: Clear lock when moving to different height
+	signState.ClearConsensusLock(HRSKey{Height: 101, Round: 5, Step: stepPrevote})
+	if signState.ConsensusLock.IsLocked() {
+		t.Error("Expected lock to be cleared when moving to different height")
+	}
+
+	// Reset the lock
+	signState.ConsensusLock = ConsensusLock{
+		Height:    100,
+		Round:     5,
+		Value:     lockedValue[:32],
+		ValueType: "block",
+	}
+
+	// Test 2: Don't clear lock when moving to higher round (locks persist for all future rounds)
+	signState.ClearConsensusLock(HRSKey{Height: 100, Round: 6, Step: stepPrevote})
+	if !signState.ConsensusLock.IsLocked() {
+		t.Error("Expected lock to remain when moving to higher round (locks persist for all future rounds)")
+	}
+
+	// Reset the lock
+	signState.ConsensusLock = ConsensusLock{
+		Height:    100,
+		Round:     5,
+		Value:     lockedValue[:32],
+		ValueType: "block",
+	}
+
+	// Test 3: Don't clear lock when moving to same or lower round
+	signState.ClearConsensusLock(HRSKey{Height: 100, Round: 5, Step: stepPrevote})
+	if !signState.ConsensusLock.IsLocked() {
+		t.Error("Expected lock to remain when moving to same round")
+	}
+
+	signState.ClearConsensusLock(HRSKey{Height: 100, Round: 4, Step: stepPrevote})
+	if !signState.ConsensusLock.IsLocked() {
+		t.Error("Expected lock to remain when moving to lower round")
+	}
+}

--- a/signer/consensus_lock_simple_test.go
+++ b/signer/consensus_lock_simple_test.go
@@ -62,7 +62,7 @@ func TestConsensusLockBasic(t *testing.T) {
 	// Test updating lock on PRECOMMIT
 	blockHash := []byte("new_block_hash_123456789012345678901234567890")[:32] // 32 bytes
 	signBytes := createTestSignBytes(blockHash, stepPrecommit)
-	signState.ConsensusLock = updateConsensusLock(
+	signState.ConsensusLock = nextConsensusLock(
 		signState.ConsensusLock, HRSKey{Height: 100, Round: 5, Step: stepPrecommit}, signBytes)
 
 	if !signState.ConsensusLock.IsLocked() {
@@ -174,14 +174,15 @@ func TestConsensusLockErrorTypes(t *testing.T) {
 	}
 
 	// Test that we don't get an error for the same value
-	sameBlockBytes := []byte("locked_block_hash_123456789012345678901234567890")
+	sameBlockBytes := createTestSignBytes(lockedValue[:32], stepPrevote)
 	err = signState.ValidateConsensusLock(HRSKey{Height: 100, Round: 6, Step: stepPrevote}, sameBlockBytes)
 	if err != nil {
 		t.Errorf("Expected no error for same value, got: %v", err)
 	}
 
 	// Test that we don't get an error for different height
-	err = signState.ValidateConsensusLock(HRSKey{Height: 101, Round: 5, Step: stepPrevote}, differentBlockBytes)
+	differentHeightBytes := createTestSignBytes(differentBlockHash, stepPrevote)
+	err = signState.ValidateConsensusLock(HRSKey{Height: 101, Round: 5, Step: stepPrevote}, differentHeightBytes)
 	if err != nil {
 		t.Errorf("Expected no error for different height, got: %v", err)
 	}

--- a/signer/consensus_lock_simple_test.go
+++ b/signer/consensus_lock_simple_test.go
@@ -23,7 +23,8 @@ func TestConsensusLockBasic(t *testing.T) {
 
 	// Test updating lock on PRECOMMIT
 	blockHash := []byte("new_block_hash_123456789012345678901234567890") // 32 bytes
-	signState.ConsensusLock = updateConsensusLock(signState.ConsensusLock, HRSKey{Height: 100, Round: 5, Step: stepPrecommit}, blockHash)
+	signState.ConsensusLock = updateConsensusLock(
+		signState.ConsensusLock, HRSKey{Height: 100, Round: 5, Step: stepPrecommit}, blockHash)
 
 	if !signState.ConsensusLock.IsLocked() {
 		t.Error("Expected consensus lock to be set after PRECOMMIT")

--- a/signer/cosigner.go
+++ b/signer/cosigner.go
@@ -54,6 +54,7 @@ type CosignerSignRequest struct {
 	UUID                   uuid.UUID
 	VoteExtensionSignBytes []byte
 	VoteExtUUID            uuid.UUID
+	PolRound               int64 `json:"pol_round,omitempty"`
 }
 
 type CosignerSignResponse struct {

--- a/signer/local_cosigner.go
+++ b/signer/local_cosigner.go
@@ -220,13 +220,15 @@ func (cosigner *LocalCosigner) sign(req CosignerSignRequest) (CosignerSignRespon
 	}
 
 	// Check for consensus lock violations before proceeding
-	if err := ccs.lastSignState.ValidateConsensusLock(hrst.HRSKey(), req.SignBytes); err != nil {
+	// Use POL round validation
+	if err := ccs.lastSignState.ValidateConsensusLock(hrst.HRSKey(), req.SignBytes, req.PolRound); err != nil {
 		// Log the specific consensus lock violation with context
 		cosigner.logger.Error("Consensus lock violation in local cosigner",
 			"chain_id", chainID,
 			"height", hrst.Height,
 			"round", hrst.Round,
 			"step", hrst.Step,
+			"pol_round", req.PolRound,
 			"error", err,
 		)
 		// Return the specific consensus lock violation error with full details

--- a/signer/local_cosigner.go
+++ b/signer/local_cosigner.go
@@ -306,7 +306,7 @@ func (cosigner *LocalCosigner) sign(req CosignerSignRequest) (CosignerSignRespon
 	}
 
 	// Handle consensus lock updates according to Tendermint rules
-	signStateConsensus.ConsensusLock = updateConsensusLock(ccs.lastSignState.ConsensusLock, hrst.HRSKey(), req.SignBytes)
+	signStateConsensus.ConsensusLock = nextConsensusLock(ccs.lastSignState.ConsensusLock, hrst.HRSKey(), req.SignBytes)
 
 	err = ccs.lastSignState.Save(signStateConsensus, &cosigner.pendingDiskWG)
 

--- a/signer/proto/cosigner.pb.go
+++ b/signer/proto/cosigner.pb.go
@@ -6,14 +6,15 @@ package proto
 import (
 	context "context"
 	fmt "fmt"
+	io "io"
+	math "math"
+	math_bits "math/bits"
+
 	grpc1 "github.com/cosmos/gogoproto/grpc"
 	proto "github.com/cosmos/gogoproto/proto"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
-	io "io"
-	math "math"
-	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -34,6 +35,7 @@ type Block struct {
 	SignBytes        []byte `protobuf:"bytes,4,opt,name=signBytes,proto3" json:"signBytes,omitempty"`
 	VoteExtSignBytes []byte `protobuf:"bytes,5,opt,name=voteExtSignBytes,proto3" json:"voteExtSignBytes,omitempty"`
 	Timestamp        int64  `protobuf:"varint,6,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	PolRound         int64  `protobuf:"varint,7,opt,name=pol_round,json=polRound,proto3" json:"pol_round,omitempty"`
 }
 
 func (m *Block) Reset()         { *m = Block{} }

--- a/signer/threshold_signer_soft.go
+++ b/signer/threshold_signer_soft.go
@@ -106,12 +106,12 @@ func GenerateNonces(threshold, total uint8) (Nonces, error) {
 }
 
 func (s *ThresholdSignerSoft) CombineSignatures(signatures []PartialSignature) ([]byte, error) {
-	sigIds := make([]int, len(signatures))
+	sigIDs := make([]int, len(signatures))
 	shareSigs := make([][]byte, len(signatures))
 	var ephPub []byte
 
 	for i, sig := range signatures {
-		sigIds[i] = sig.ID
+		sigIDs[i] = sig.ID
 		if i == 0 {
 			ephPub = sig.Signature[:32]
 		} else if !bytes.Equal(sig.Signature[:32], ephPub) {
@@ -119,7 +119,7 @@ func (s *ThresholdSignerSoft) CombineSignatures(signatures []PartialSignature) (
 		}
 		shareSigs[i] = sig.Signature[32:]
 	}
-	combinedSig := tsed25519.CombineShares(s.total, sigIds, shareSigs)
+	combinedSig := tsed25519.CombineShares(s.total, sigIDs, shareSigs)
 
 	return append(ephPub, combinedSig...), nil
 }

--- a/signer/threshold_validator.go
+++ b/signer/threshold_validator.go
@@ -975,7 +975,7 @@ func (pv *ThresholdValidator) Sign(
 	}
 
 	// Handle consensus lock updates according to Tendermint rules
-	newLss.SignStateConsensus.ConsensusLock = updateConsensusLock(
+	newLss.SignStateConsensus.ConsensusLock = nextConsensusLock(
 		css.lastSignState.ConsensusLock, block.HRSKey(), signBytes)
 
 	// Err will be present if newLss is not above high watermark

--- a/signer/threshold_validator.go
+++ b/signer/threshold_validator.go
@@ -672,6 +672,13 @@ func (pv *ThresholdValidator) Sign(
 		Timestamp: stamp.UnixNano(),
 	}
 
+	// Check for consensus lock violations before proceeding
+	css := pv.mustLoadChainState(chainID)
+	if err := css.lastSignState.ValidateConsensusLock(block.HRSKey(), signBytes); err != nil {
+		log.Error("Consensus lock violation detected", "error", err)
+		return nil, nil, stamp, fmt.Errorf("consensus lock violation: %w", err)
+	}
+
 	// Keep track of the last block that we began the signing process for. Only allow one attempt per block
 	existingSignature, existingVoteExtSig, existingTimestamp, err := pv.SaveLastSignedStateInitiated(chainID, &block)
 	if err != nil {
@@ -945,6 +952,7 @@ func (pv *ThresholdValidator) Sign(
 		}
 	}
 
+	// Create the new sign state with consensus lock
 	newLss := ChainSignStateConsensus{
 		ChainID: chainID,
 		SignStateConsensus: SignStateConsensus{
@@ -954,10 +962,50 @@ func (pv *ThresholdValidator) Sign(
 			Signature:              signature,
 			SignBytes:              signBytes,
 			VoteExtensionSignature: voteExtSig,
+			ConsensusLock:          css.lastSignState.ConsensusLock, // Preserve existing lock
 		},
 	}
 
-	css := pv.mustLoadChainState(chainID)
+	// Handle consensus lock updates according to Tendermint rules
+	if step == stepPrecommit {
+		// Extract the block hash from the sign bytes
+		blockHash := extractBlockHashFromSignBytes(signBytes, step)
+		if blockHash != nil {
+			// Rule 1.2: If PRECOMMIT for V' is signed in round R' > R where V' != V,
+			// then lock on V' instead for all rounds R'' > R'
+			if round > css.lastSignState.ConsensusLock.Round &&
+				css.lastSignState.ConsensusLock.IsLocked() &&
+				!bytes.Equal(blockHash, css.lastSignState.ConsensusLock.Value) {
+				// Release old lock and set new lock on V'
+				newLss.SignStateConsensus.ConsensusLock = ConsensusLock{
+					Height:    height,
+					Round:     round,
+					Value:     blockHash,
+					ValueType: "block",
+				}
+			} else if !css.lastSignState.ConsensusLock.IsLocked() {
+				// First lock for this height
+				newLss.SignStateConsensus.ConsensusLock = ConsensusLock{
+					Height:    height,
+					Round:     round,
+					Value:     blockHash,
+					ValueType: "block",
+				}
+			} else {
+				// If PRECOMMIT for same value V in higher round, keep existing lock (no change needed)
+				newLss.SignStateConsensus.ConsensusLock = css.lastSignState.ConsensusLock
+			}
+		}
+	} else {
+		// For non-PRECOMMIT steps, only clear lock if moving to different height
+		// Locks persist for all future rounds within the same height
+		if height != css.lastSignState.ConsensusLock.Height {
+			newLss.SignStateConsensus.ConsensusLock = ConsensusLock{}
+		} else {
+			// Preserve existing lock
+			newLss.SignStateConsensus.ConsensusLock = css.lastSignState.ConsensusLock
+		}
+	}
 
 	// Err will be present if newLss is not above high watermark
 	css.lastSignStateMutex.Lock()

--- a/signer/threshold_validator.go
+++ b/signer/threshold_validator.go
@@ -975,7 +975,8 @@ func (pv *ThresholdValidator) Sign(
 	}
 
 	// Handle consensus lock updates according to Tendermint rules
-	newLss.SignStateConsensus.ConsensusLock = updateConsensusLock(css.lastSignState.ConsensusLock, block.HRSKey(), signBytes)
+	newLss.SignStateConsensus.ConsensusLock = updateConsensusLock(
+		css.lastSignState.ConsensusLock, block.HRSKey(), signBytes)
 
 	// Err will be present if newLss is not above high watermark
 	css.lastSignStateMutex.Lock()


### PR DESCRIPTION
## Problem Description

This implementation addresses a critical safety vulnerability (#308 ) in Horcrux that can lead to chain forks in Tendermint-based networks. The vulnerability, known as the "amnesia fault," occurs when Horcrux nodes in a distributed validator setup lose track of their consensus locks due to network partitions, allowing them to sign conflicting blocks.

### The Amnesia Fault Scenario

1. **Network Partition**: The network splits into groups A, B, and C
2. **Partial Lock**: Group A sees enough prevotes to lock on Block V at Round R
3. **Missing Lock**: Group B doesn't see the prevotes and remains unlocked
4. **Network Recovery**: When the network recovers, Group B can sign a conflicting Block W
5. **Chain Fork**: This leads to a chain fork as different parts of the network have committed different blocks

### Root Cause

The root cause is that **Horcrux is stateless with respect to Tendermint consensus locks**. The remote signer only tracks what it has signed (high watermark) but doesn't maintain the consensus-critical state of what the validator is locked on. This allows the validator to "forget" its lock and sign conflicting blocks.

## Solution Overview

This implementation adds **consensus lock tracking** to Horcrux, making the remote signer consensus-aware. The solution ensures that:

1. **Lock Tracking**: The system tracks what block/value the validator is locked on
2. **Lock Validation**: Before signing any block, the system checks if it would violate an existing lock
3. **Lock Updates**: Locks are updated when PRECOMMIT messages are signed according to Tendermint rules
4. **Lock Persistence**: Locks persist for all future rounds within the same height

## Tendermint Locking Rules Implementation

The implementation follows the correct Tendermint consensus locking rules:

**If a PRECOMMIT for value V is signed in round R for tendermint's consensus instance Id then:**

1. **Rule 1.1 [lock on V]**: For PROPOSAL and PREVOTE messages, allow only signing for V in rounds R' ≥ R
2. **Rule 1.2 [lock on V']**: If a PRECOMMIT message for V' is requested and signed in round R' > R such that V' ≠ V, then lock on V' instead for all rounds R'' > R'

**Key Points:**
- Locks persist for ALL future rounds within the same height
- Locks are only cleared when moving to a different height
- PRECOMMIT messages in later rounds can release and set new locks
- PROPOSAL and PREVOTE messages in later rounds must respect the existing lock

## Implementation Details

### Data Structures

#### ConsensusLock
```go
type ConsensusLock struct {
    Height    int64  `json:"height"`
    Round     int64  `json:"round"`
    Value     []byte `json:"value,omitempty"`     // The locked block hash/value
    ValueType string `json:"value_type"`         // "block" or "nil"
}
```

#### Updated SignState
The `SignState` structure now includes a `ConsensusLock` field to track the current consensus lock state.

### Key Functions

#### ValidateConsensusLock
```go
func (signState *SignState) ValidateConsensusLock(hrs HRSKey, signBytes []byte) error
```
- Checks if signing the given block would violate an existing consensus lock
- Returns an error if the lock would be violated
- Allows signing if no lock exists or if the lock is not applicable

#### Lock Update Logic
The consensus lock is updated in three scenarios:
1. **First lock for height**: When no lock exists, set the lock based on PRECOMMIT
2. **Lock release/update**: When PRECOMMIT for different value V' is signed in higher round R' > R
3. **Lock preservation**: When PRECOMMIT for same value V is signed in higher round (no change needed)

### Integration Points

#### ThresholdValidator.Sign()
- Added consensus lock validation before proceeding with signing
- Updates consensus lock when PRECOMMIT is signed
- Preserves existing lock state in sign state consensus

#### LocalCosigner.sign()
- Added consensus lock validation before local signing
- Updates consensus lock when PRECOMMIT is signed locally

#### SignState.blockDoubleSign()
- Added consensus lock validation as the first check
- Ensures lock violations are caught early in the signing process