### PR TITLE
Fix Writable file handle closed without error handling

### DIFF
--- a/signer/services.go
+++ b/signer/services.go
@@ -82,9 +82,12 @@ func WaitAndTerminate(logger cometlog.Logger, services []cometservice.Service, p
 		panic(fmt.Errorf("error opening PID file: %s. %w", pidFilePath, err))
 	}
 	_, err = pidFile.Write([]byte(fmt.Sprintf("%d\n", os.Getpid())))
-	pidFile.Close()
 	if err != nil {
+		_ = pidFile.Close()
 		panic(fmt.Errorf("error writing to lock file: %s. %w", pidFilePath, err))
+	}
+	if err := pidFile.Close(); err != nil {
+		panic(fmt.Errorf("error closing PID file: %s. %w", pidFilePath, err))
 	}
 	cometos.TrapSignal(logger, func() {
 		if err := os.Remove(pidFilePath); err != nil {


### PR DESCRIPTION
Handle the `Close()` error explicitly after writing the PID file, and ensure it is reported similarly to existing write/open failures.
fix `signer/services.go` inside `WaitAndTerminate`, after `pidFile.Write(...)`, replace the bare `pidFile.Close()` with checked close logic:
1. Keep `Write` error handling.
2. Call `pidFile.Close()` and check its error.
3. Panic with contextual message if close fails.

This is localized to the PID file creation block (lines ~80–88 in the provided snippet).