### PR TITLE
Fix Import math package for leader range checks

### DIFF
--- a/signer/cosigner_grpc_server.go
+++ b/signer/cosigner_grpc_server.go
@@ -3,6 +3,7 @@ package signer
 import (
 	"context"
 	"fmt"
+	"math"
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/raft"
@@ -146,6 +147,9 @@ func (rpc *CosignerGRPCServer) GetLeader(
 	*proto.GetLeaderRequest,
 ) (*proto.GetLeaderResponse, error) {
 	leader := rpc.raftStore.GetLeader()
+	if leader < math.MinInt32 || leader > math.MaxInt32 {
+		return &proto.GetLeaderResponse{Leader: -1}, nil
+	}
 	return &proto.GetLeaderResponse{Leader: int32(leader)}, nil
 }
 

--- a/signer/services.go
+++ b/signer/services.go
@@ -3,6 +3,7 @@ package signer
 import (
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"strconv"
 	"strings"
@@ -33,13 +34,17 @@ func RequireNotRunning(log cometlog.Logger, pidFilePath string) error {
 		return fmt.Errorf("unexpected error parsing PID from PID file: %s. manual deletion of PID file required. %w",
 			pidFilePath, err)
 	}
+	if pid <= 0 || pid > math.MaxInt32 {
+		return fmt.Errorf("invalid PID value in PID file: %s, PID: %d", pidFilePath, pid)
+	}
+	pidInt := int(pid)
 
-	if int(pid) == os.Getpid() {
+	if pidInt == os.Getpid() {
 		panic(fmt.Errorf("error checking PID file: %s, PID: %d matches current process",
 			pidFilePath, pid))
 	}
 
-	process, err := os.FindProcess(int(pid))
+	process, err := os.FindProcess(pidInt)
 	if err != nil {
 		return fmt.Errorf("error checking pid %d: %w", pid, err)
 	}


### PR DESCRIPTION
Add math import for leader validation in GetLeader method, Use an explicit `int32` range check before converting `leader` in `CosignerGRPCServer.GetLeader`.   Best minimal fix (without changing existing behavior for valid values): if `leader` is outside `[math.MinInt32, math.MaxInt32]`, return a safe fallback (`-1`, consistent with existing “unknown leader” sentinel), otherwise cast to `int32`.

Changes needed:
- `signer/cosigner_grpc_server`
  - Add `math` import.
  - Update `GetLeader` method to perform bounds check before `int32(leader)` conversion.


If a string is parsed into an int using `strconv.Atoi`, and subsequently that int is converted into another integer type of a smaller size, the result can produce unexpected values.

This also applies to the results of `strconv.ParseInt` and `strconv.ParseUint` when the specified size is larger than the size of the type that number is converted to.

**References**
[doc strconv.Atoi](https://golang.org/pkg/strconv/#Atoi)
[doc strconv.ParseInt](https://golang.org/pkg/strconv/#ParseInt)
[doc strconv.ParseUint](https://golang.org/pkg/strconv/#ParseUint)
